### PR TITLE
fix build version indicator

### DIFF
--- a/src/components/AppVersion/index.tsx
+++ b/src/components/AppVersion/index.tsx
@@ -46,10 +46,6 @@ export const AppVersion: React.FC<AppVersionProps> = ({
         }
 
         const info: AppVersionInfo = {
-          buildDate:
-            (buildInfo as any)?.buildDate ||
-            __BUILD_DATE__ ||
-            new Date().toISOString(),
           commit: (buildInfo as any)?.commit || __GIT_COMMIT__ || 'unknown',
           environment:
             (buildInfo as any)?.environment || __NODE_ENV__ || 'development',


### PR DESCRIPTION
- adding `reqwest` library to `Cargo.toml` for HTTP data-fetching with rust in backend
- fetching data from `https://github.com/kaleidoswap/desktop-app/releases/download/{version}/latest.json`