### PR TITLE
perf/fix: trading init optimizations, Docker smart resume, dashboard asset loading

### DIFF
--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -869,7 +869,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({ isCollapsed = false }) => {
 
           if (dockerEnv) {
             // If the Docker containers are already running and reachable, just navigate — don't restart
-            const alreadyRunning = await navigateFromNodeStatus(5000).catch(() => false)
+            const alreadyRunning = await navigateFromNodeStatus(5000).catch(
+              () => false
+            )
             if (alreadyRunning) return
 
             toast.info(

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -868,6 +868,10 @@ export const Toolbar: React.FC<ToolbarProps> = ({ isCollapsed = false }) => {
           )
 
           if (dockerEnv) {
+            // If the Docker containers are already running and reachable, just navigate — don't restart
+            const alreadyRunning = await navigateFromNodeStatus(5000).catch(() => false)
+            if (alreadyRunning) return
+
             toast.info(
               t('toolbar.nodes.startingDockerNode', {
                 defaultValue: 'Starting Docker node...',

--- a/src/routes/trade/market-maker/MarketMakerTradingPage.tsx
+++ b/src/routes/trade/market-maker/MarketMakerTradingPage.tsx
@@ -711,17 +711,17 @@ export const Component = () => {
   const [getInfo] = makerApi.endpoints.get_info.useLazyQuery()
 
   // Function to get SDK client for maker API calls
-  const state = useAppSelector((state) => state)
+  const nodeSettings = useAppSelector((state) => state.nodeSettings)
   const getClient = useCallback(async () => {
-    return await getKaleidoClient(state)
-  }, [state])
+    return await getKaleidoClient({ nodeSettings })
+  }, [nodeSettings])
 
   const { data: assetsData } = nodeApi.endpoints.listAssets.useQuery(
     undefined,
     {
       pollingInterval: 30000,
       refetchOnFocus: false,
-      refetchOnMountOrArgChange: true,
+      refetchOnMountOrArgChange: false,
       refetchOnReconnect: false,
     }
   )
@@ -2008,48 +2008,41 @@ export const Component = () => {
       setupRunningRef.current = true
 
       try {
-        // Phase 1: Get node info and channels first
-
-        // Always fetch BTC balance and LSP info for potential onchain trading
-        logger.info('💰 Fetching BTC balance and LSP info...')
+        // Phase 1: Fetch all independent data in parallel
+        logger.info('🚀 Fetching balance, LSP info, node info, and channels in parallel...')
         setLoadingPhase('validating-balance')
 
-        const balanceResponse = await btcBalance()
+        const [balanceResponse, lspInfoResult, nodeInfoResponse, channelsResponse] =
+          await Promise.all([
+            btcBalance(),
+            getInfo().catch((error: any) => {
+              if (error?.status === 'TIMEOUT_ERROR') {
+                logger.warn(
+                  '⚠️ LSP info request timed out - maker server not responding. Continuing without channel limits.'
+                )
+              } else {
+                logger.warn(
+                  '⚠️ Failed to fetch LSP info, continuing without channel limits:',
+                  error
+                )
+              }
+              return null
+            }),
+            nodeInfo(),
+            listChannels(),
+          ])
+
+        const lspInfoResponse: any =
+          lspInfoResult && 'error' in lspInfoResult && lspInfoResult.error
+            ? (logger.warn('⚠️ LSP info fetch failed, continuing without channel limits'), null)
+            : lspInfoResult
 
         if (!('data' in balanceResponse) || !balanceResponse.data) {
           logger.error('❌ Failed to get balance data')
           throw new Error('Failed to get balance information')
         }
 
-        let lspInfoResponse: any = null
-        try {
-          lspInfoResponse = await getInfo()
-          if (lspInfoResponse.error) {
-            logger.warn(
-              '⚠️ LSP info fetch failed, continuing without channel limits'
-            )
-          }
-        } catch (error: any) {
-          if (error?.status === 'TIMEOUT_ERROR') {
-            logger.warn(
-              '⚠️ LSP info request timed out - maker server not responding. Continuing without channel limits.'
-            )
-          } else {
-            logger.warn(
-              '⚠️ Failed to fetch LSP info, continuing without channel limits:',
-              error
-            )
-          }
-        }
-
-        logger.info('🔗 Phase 1: Checking channels and node info')
         setLoadingPhase('validating-channels')
-
-        // Get node info and channels in parallel
-        const [nodeInfoResponse, channelsResponse] = await Promise.all([
-          nodeInfo(),
-          listChannels(),
-        ])
 
         // Validate node info
         if (!('data' in nodeInfoResponse) || !nodeInfoResponse.data) {

--- a/src/routes/trade/market-maker/MarketMakerTradingPage.tsx
+++ b/src/routes/trade/market-maker/MarketMakerTradingPage.tsx
@@ -2009,32 +2009,41 @@ export const Component = () => {
 
       try {
         // Phase 1: Fetch all independent data in parallel
-        logger.info('🚀 Fetching balance, LSP info, node info, and channels in parallel...')
+        logger.info(
+          '🚀 Fetching balance, LSP info, node info, and channels in parallel...'
+        )
         setLoadingPhase('validating-balance')
 
-        const [balanceResponse, lspInfoResult, nodeInfoResponse, channelsResponse] =
-          await Promise.all([
-            btcBalance(),
-            getInfo().catch((error: any) => {
-              if (error?.status === 'TIMEOUT_ERROR') {
-                logger.warn(
-                  '⚠️ LSP info request timed out - maker server not responding. Continuing without channel limits.'
-                )
-              } else {
-                logger.warn(
-                  '⚠️ Failed to fetch LSP info, continuing without channel limits:',
-                  error
-                )
-              }
-              return null
-            }),
-            nodeInfo(),
-            listChannels(),
-          ])
+        const [
+          balanceResponse,
+          lspInfoResult,
+          nodeInfoResponse,
+          channelsResponse,
+        ] = await Promise.all([
+          btcBalance(),
+          getInfo().catch((error: any) => {
+            if (error?.status === 'TIMEOUT_ERROR') {
+              logger.warn(
+                '⚠️ LSP info request timed out - maker server not responding. Continuing without channel limits.'
+              )
+            } else {
+              logger.warn(
+                '⚠️ Failed to fetch LSP info, continuing without channel limits:',
+                error
+              )
+            }
+            return null
+          }),
+          nodeInfo(),
+          listChannels(),
+        ])
 
         const lspInfoResponse: any =
           lspInfoResult && 'error' in lspInfoResult && lspInfoResult.error
-            ? (logger.warn('⚠️ LSP info fetch failed, continuing without channel limits'), null)
+            ? (logger.warn(
+                '⚠️ LSP info fetch failed, continuing without channel limits'
+              ),
+              null)
             : lspInfoResult
 
         if (!('data' in balanceResponse) || !balanceResponse.data) {

--- a/src/routes/wallet-dashboard/index.tsx
+++ b/src/routes/wallet-dashboard/index.tsx
@@ -202,9 +202,10 @@ export const Component = () => {
   )
 
   const isLoading =
-    btcBalanceResponse.isLoading || listChannelsResponse.isLoading
+    (btcBalanceResponse.isLoading && !btcBalanceResponse.data) ||
+    (listChannelsResponse.isLoading && !listChannelsResponse.data)
 
-  const isAssetsLoading = assetsResponse.isLoading || assetsResponse.isFetching
+  const isAssetsLoading = assetsResponse.isLoading && !assetsResponse.data
 
   const liquidityTotal = totalInboundLiquidity + totalOutboundLiquidity
   const outboundPct =

--- a/src/routes/wallet-dashboard/index.tsx
+++ b/src/routes/wallet-dashboard/index.tsx
@@ -204,6 +204,8 @@ export const Component = () => {
   const isLoading =
     btcBalanceResponse.isLoading || listChannelsResponse.isLoading
 
+  const isAssetsLoading = assetsResponse.isLoading || assetsResponse.isFetching
+
   const liquidityTotal = totalInboundLiquidity + totalOutboundLiquidity
   const outboundPct =
     liquidityTotal > 0 ? (totalOutboundLiquidity / liquidityTotal) * 100 : 50
@@ -514,7 +516,27 @@ export const Component = () => {
 
             {/* RGB asset rows — scrollable */}
             <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar">
-              {niaAssets.length === 0 ? (
+              {isAssetsLoading ? (
+                <div className="space-y-0">
+                  {[0, 1, 2].map((i) => (
+                    <div
+                      className="grid grid-cols-4 gap-2 items-center border-b border-border-default/20 px-4 py-3"
+                      key={i}
+                    >
+                      <div className="flex items-center gap-2">
+                        <div className="w-6 h-6 rounded-full bg-surface-elevated/50 animate-pulse flex-shrink-0" />
+                        <LoadingPlaceholder width="w-16" />
+                      </div>
+                      <LoadingPlaceholder />
+                      <LoadingPlaceholder />
+                      <div className="flex justify-center gap-1">
+                        <div className="w-6 h-6 rounded-lg bg-surface-elevated/50 animate-pulse" />
+                        <div className="w-6 h-6 rounded-lg bg-surface-elevated/50 animate-pulse" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : niaAssets.length === 0 ? (
                 <div className="flex flex-col items-center justify-center py-10 text-content-tertiary">
                   <Database className="w-10 h-10 mb-3 opacity-40" />
                   <p className="text-sm font-medium">No RGB assets found.</p>
@@ -529,6 +551,7 @@ export const Component = () => {
                     incomingBalance={
                       (assetBalances[asset.asset_id || ''] || {}).incoming || 0
                     }
+                    isLoading={!(asset.asset_id in assetBalances)}
                     key={asset.asset_id}
                     offChainBalance={
                       (assetBalances[asset.asset_id || ''] || {}).offChain || 0


### PR DESCRIPTION
## Summary

- **Parallel trading init**: collapsed 3 sequential API calls (`btcBalance`, `getInfo`, `nodeInfo`, `listChannels`) into a single `Promise.all`, cutting the "Initializing Trading Interface" wait by ~2–3 network round-trips
- **Remove blocking `listAssets` refetch**: changed `refetchOnMountOrArgChange` to `false` on the trading page — uses the cached result (kept fresh by 30s polling) so setup starts immediately
- **Fix root-state Redux selector**: replaced `useAppSelector(state => state)` with `useAppSelector(state => state.nodeSettings)` to eliminate unnecessary re-renders on every Redux dispatch
- **Docker smart resume**: when switching to a Docker-backed account in the toolbar, probe the node HTTP endpoint first — if already running (locked/unlocked), navigate directly without restarting containers
- **Dashboard asset loading skeletons**: show animated skeleton rows while `listAssets` is fetching, and pass `isLoading` to `AssetRow` while individual asset balances are loading — consistent with the existing BTC row behavior

## Test plan

- [ ] Open trading page — "Initializing Trading Interface" screen should be noticeably faster
- [x] Switch to a Docker account in the toolbar when containers are already running — should navigate to unlock/dashboard without restarting
- [x] Switch to a Docker account when containers are stopped — should start normally
- [ ] Open dashboard on first load — RGB asset rows should show skeleton placeholders, not "No RGB assets found"
- [ ] Verify no Redux selector warning in console (`Selector unknown returned the root state`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)