### PR TITLE
fix(signet): default to self-hosted esplora indexer

### DIFF
--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -59,7 +59,7 @@ export const NETWORK_DEFAULTS: Record<string, NetworkDefaults> = {
     daemon_listening_port: '3001',
     default_lsp_url: 'https://api.signet.kaleidoswap.com/',
     default_maker_url: 'https://api.signet.kaleidoswap.com/',
-    indexer_url: 'electrum.signet.kaleidoswap.com:60601',
+    indexer_url: 'https://esplora.signet.kaleidoswap.com',
     ldk_peer_listening_port: '9735',
     proxy_endpoint: 'rpcs://proxy.iriswallet.com/0.2/json-rpc',
     rpc_connection_url:


### PR DESCRIPTION
Point the `SignetCustom` network preset's `indexer_url` at the public esplora REST indexer:

```
indexer_url: 'https://esplora.signet.kaleidoswap.com'
```

- Verified live + public: `GET /blocks/tip/height` → `200`.
- RLN 0.7.0 / rgb-lib auto-detect Esplora from the `https://` scheme.