### PR TITLE
Bump kaleido-sdk to 0.1.11 (RLN 0.7.1 compatibility)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "decimal.js": "^10.6.0",
     "i18next": "^25.10.10",
     "i18next-browser-languagedetector": "^8.2.1",
-    "kaleido-sdk": "^0.1.8",
+    "kaleido-sdk": "^0.1.11",
     "lucide-react": "^0.575.0",
     "minidenticons": "^4.2.1",
     "qrcode.react": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^8.2.1
         version: 8.2.1
       kaleido-sdk:
-        specifier: ^0.1.8
-        version: 0.1.8
+        specifier: ^0.1.11
+        version: 0.1.11(typescript@5.9.3)
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@18.3.1)
@@ -174,7 +174,7 @@ importers:
         version: 9.1.7
       jsdom:
         specifier: ^29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.0.1)
       lint-staged:
         specifier: ^15.5.2
         version: 15.5.2
@@ -201,7 +201,7 @@ importers:
         version: 0.25.0(rollup@4.62.0)(vite@7.3.5(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@25.5.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.9.0))
+        version: 4.1.9(@types/node@25.5.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.5(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.9.0))
 
 packages:
 
@@ -626,6 +626,18 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@noble/ciphers@2.1.1':
+    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@2.0.1':
+    resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -797,6 +809,15 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@scure/base@2.0.0':
+    resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+
+  '@scure/bip32@2.0.1':
+    resolution: {integrity: sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==}
+
+  '@scure/bip39@2.0.1':
+    resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2396,8 +2417,8 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
-  kaleido-sdk@0.1.8:
-    resolution: {integrity: sha512-NCb5fHEjqJf5vwPj6mSvRjtq+v4Y1XqdkldiT2L8k/Gq66gGPPn6Tt8ixDbw6B2LpWmqbk+RM3H5p+joLtWD0Q==}
+  kaleido-sdk@0.1.11:
+    resolution: {integrity: sha512-I0X2up8GQoL+oX8HW+YnN7rl+PYSsi4gvtEMBO7ZA8iUcHRUtc0+mfpCpW9NEOcioqN02748ddg4U7/XyfXCHw==}
     engines: {node: '>=18.0.0'}
 
   keyv@4.5.4:
@@ -2650,6 +2671,17 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  nostr-tools@2.23.5:
+    resolution: {integrity: sha512-Fa7ZlUdjfUW1P4E7H3yBexhOHYi18XNyvd2n7eNHkYR085xADX6Y8V8Vm7nT/XQajaFOBrptXmVIGkJ2E4vfVw==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  nostr-wasm@0.1.0:
+    resolution: {integrity: sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -3985,7 +4017,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.1': {}
+  '@exodus/bytes@1.15.1(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
 
   '@hookform/resolvers@3.10.0(react-hook-form@7.79.0(react@18.3.1))':
     dependencies:
@@ -4032,6 +4066,14 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@noble/ciphers@2.1.1': {}
+
+  '@noble/curves@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+
+  '@noble/hashes@2.0.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4151,6 +4193,19 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@scure/base@2.0.0': {}
+
+  '@scure/bip32@2.0.1':
+    dependencies:
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+
+  '@scure/bip39@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4550,7 +4605,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@25.5.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@25.5.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.5(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.9.0))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -5019,10 +5074,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@2.0.1):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -5706,9 +5761,9 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
     dependencies:
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -5963,17 +6018,17 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.1.1:
+  jsdom@29.1.1(@noble/hashes@2.0.1):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.0.1)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@2.0.1)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.1
       parse5: 8.0.1
@@ -5984,7 +6039,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -6010,9 +6065,12 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
-  kaleido-sdk@0.1.8:
+  kaleido-sdk@0.1.11(typescript@5.9.3):
     dependencies:
+      nostr-tools: 2.23.5(typescript@5.9.3)
       openapi-fetch: 0.15.2
+    transitivePeerDependencies:
+      - typescript
 
   keyv@4.5.4:
     dependencies:
@@ -6421,6 +6479,20 @@ snapshots:
       vm-browserify: 1.1.2
 
   normalize-path@3.0.0: {}
+
+  nostr-tools@2.23.5(typescript@5.9.3):
+    dependencies:
+      '@noble/ciphers': 2.1.1
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+      '@scure/bip32': 2.0.1
+      '@scure/bip39': 2.0.1
+      nostr-wasm: 0.1.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  nostr-wasm@0.1.0: {}
 
   npm-run-path@5.3.0:
     dependencies:
@@ -7455,7 +7527,7 @@ snapshots:
       jiti: 1.21.7
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@25.5.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@25.5.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.5(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@25.5.0)(jiti@1.21.7)(yaml@2.9.0))
@@ -7480,7 +7552,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
-      jsdom: 29.1.1
+      jsdom: 29.1.1(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - msw
 
@@ -7498,9 +7570,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@2.0.1):
     dependencies:
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.0.1)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:

--- a/src/api/node-api-wrapper.ts
+++ b/src/api/node-api-wrapper.ts
@@ -57,7 +57,7 @@ import type {
   TakerRequest as WhitelistTradeRequest,
 } from 'kaleido-sdk/rln'
 
-import { ensureSkipSync } from './request-defaults'
+import { ensureRefreshDefaults, ensureSkipSync } from './request-defaults'
 import { transformSdkError } from './errors'
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 
@@ -71,7 +71,7 @@ export type OpenChannelInput = Omit<
   OpenChannelRequest,
   'public' | 'push_msat' | 'with_anchors'
 >
-export type RefreshInput = Partial<Pick<RefreshRequest, 'skip_sync'>>
+export type RefreshInput = Partial<Pick<RefreshRequest, 'skip_sync' | 'filter'>>
 export type SendBtcInput = Omit<SendBtcRequest, 'skip_sync'>
 // SendRgbRequest no longer carries skip_sync as of kaleido-sdk 0.1.8.
 export type SendRgbInput = SendRgbRequest
@@ -195,7 +195,7 @@ export class NodeApiWrapper {
 
   async refreshTransfers(request?: RefreshInput): Promise<ApiResult<void>> {
     return this.execute(() =>
-      this.client.refreshTransfers(ensureSkipSync(request || {}))
+      this.client.refreshTransfers(ensureRefreshDefaults(request || {}))
     )
   }
 

--- a/src/api/request-defaults.ts
+++ b/src/api/request-defaults.ts
@@ -41,6 +41,23 @@ export function ensureSkipSync<T extends Partial<SkipSyncRequest>>(
 }
 
 /**
+ * Ensure a RefreshRequest carries its required fields.
+ *
+ * RLN 0.7.1 made `filter` required on /refreshtransfers (kaleido-sdk 0.1.10+).
+ * An empty filter refreshes all pending transfers, matching the prior
+ * filter-less behavior.
+ */
+export function ensureRefreshDefaults(
+  request: Partial<RefreshRequest>
+): RefreshRequest {
+  return {
+    filter: [],
+    skip_sync: DEFAULT_SKIP_SYNC,
+    ...request,
+  }
+}
+
+/**
  * Request options for node API calls
  */
 export interface NodeRequestOptions {


### PR DESCRIPTION
Updates the desktop node API to the RLN 0.7.1 SDK (`kaleido-sdk` `^0.1.8` → `^0.1.11`).

## What changed
- **`refreshTransfers`** now sends the required `filter` field. RLN 0.7.1 made `filter` mandatory on `RefreshRequest` (`POST /refreshtransfers`); the old `{skip_sync}`-only body is rejected with HTTP 400. Added `ensureRefreshDefaults()` (fills `filter: []` = refresh all pending transfers, plus `skip_sync`) and widened `RefreshInput` to accept an optional `filter`.
- **`listUnspents`** / **`sendRgb`** — handled by the SDK itself: `listUnspents()` now defaults `settled_only`, and the `/sendasset` → `/sendrgb` rename was already adopted here. No call-site changes needed.

## SDK background
The 0.7.1 migration shipped as `kaleido-sdk` `0.1.9` → `0.1.11`:
- `0.1.9` — RLN 0.7.1 spec regen + NWC client (`kaleido-sdk/nwc`)
- `0.1.10` — fix TS `listUnspents()` missing `settled_only`
- `0.1.11` — default `filter: []` for `refreshTransfers()` (TS + Python)

## Verification
- `tsc --noEmit` clean
- `eslint` clean