### PR TITLE
feat(mind): remote-node function calling + bundled-sidecar runtime foundation

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -110,6 +110,25 @@ fn main() {
                 // when the frontend detects the node is unlocked.
                 db::init();
 
+                // Production: point the KaleidoMind sidecar at the BUNDLED
+                // provider + MCP server (dev runs them from the sibling repos;
+                // a packaged .app/.exe has neither). mind.rs reads these env
+                // vars first (resolve_provider_dir / resolve_mcp_path) and
+                // existence-checks them, so this is a safe no-op until the
+                // `bundle.resources` actually ship these paths.
+                if let Ok(res) = app.path().resource_dir() {
+                    let provider = res.join("kaleido-mind/apps/provider");
+                    if provider.join("dist/index.js").exists() {
+                        std::env::set_var("KALEIDO_MIND_PROVIDER_DIR", &provider);
+                        log::info!("[mind] bundled provider dir: {}", provider.display());
+                    }
+                    let mcp = res.join("kaleido-mcp/dist/index.js");
+                    if mcp.exists() {
+                        std::env::set_var("KALEIDO_MCP_PATH", &mcp);
+                        log::info!("[mind] bundled mcp entry: {}", mcp.display());
+                    }
+                }
+
                 // Set up system tray
                 tray::setup_tray(app.handle(), Arc::clone(&node_process))?;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -127,6 +127,21 @@ fn main() {
                         std::env::set_var("KALEIDO_MCP_PATH", &mcp);
                         log::info!("[mind] bundled mcp entry: {}", mcp.display());
                     }
+                    // A Node runtime shipped with the app (so a packaged build
+                    // doesn't require system Node). Tries node[.exe] at the
+                    // resource root or under bin/.
+                    for cand in [
+                        res.join("node"),
+                        res.join("node.exe"),
+                        res.join("bin/node"),
+                        res.join("bin/node.exe"),
+                    ] {
+                        if cand.exists() {
+                            std::env::set_var("KALEIDO_NODE_BIN", &cand);
+                            log::info!("[mind] bundled node: {}", cand.display());
+                            break;
+                        }
+                    }
                 }
 
                 // Set up system tray

--- a/src-tauri/src/mind.rs
+++ b/src-tauri/src/mind.rs
@@ -204,8 +204,15 @@ fn resolve_sidecar_command() -> Result<(String, Vec<String>, Option<PathBuf>), S
 
     let dist_entry = dir.join("dist").join("index.js");
     if dist_entry.exists() {
+        // Prefer a Node runtime BUNDLED with the app (KALEIDO_NODE_BIN, set from
+        // the resource dir in main.rs) so a packaged build doesn't depend on the
+        // user having Node installed; fall back to `node` on PATH for dev.
+        let node = std::env::var("KALEIDO_NODE_BIN")
+            .ok()
+            .filter(|p| !p.trim().is_empty())
+            .unwrap_or_else(|| "node".to_string());
         return Ok((
-            "node".to_string(),
+            node,
             vec![dist_entry.to_string_lossy().to_string()],
             Some(dir),
         ));

--- a/src-tauri/src/mind.rs
+++ b/src-tauri/src/mind.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 
 pub const MIND_EVENT: &str = "mind-event";
 
@@ -88,6 +88,23 @@ impl MindProcess {
             None => log::warn!(
                 "[mind] kaleido-mcp not found — chat runs tool-less; set KALEIDO_MCP_PATH"
             ),
+        }
+
+        // Point the MCP server at the ACTIVE node so balances/channels work for
+        // remote nodes too — not just the localhost:3001 default. The current
+        // account's node_url is the RLN node HTTP API the rest of the app uses.
+        if let Some(url) = app
+            .try_state::<crate::CurrentAccount>()
+            .and_then(|acc| {
+                acc.0
+                    .read()
+                    .ok()
+                    .and_then(|g| g.as_ref().map(|a| a.node_url.clone()))
+            })
+            .filter(|u| !u.trim().is_empty())
+        {
+            log::info!("[mind] RLN_NODE_URL={}", url);
+            cmd.env("RLN_NODE_URL", url);
         }
 
         let mut child = cmd


### PR DESCRIPTION
## #2 — Remote-node function calling (the real fix)
`mind.rs:ensure_started` now sets `RLN_NODE_URL` from the **current account's node_url**, so the agent's MCP tools reach the user's node whether it's local or remote (was hardcoded to localhost:3001). Lazy-spawn caveat: the sidecar reads the URL at spawn, so connect the node before first chat (or restart) — switching nodes mid-session needs a sidecar restart; noted for follow-up.

## #1 — Production-bundling **foundation** (no-op until artifacts ship)
- setup hook points `KALEIDO_MIND_PROVIDER_DIR` / `KALEIDO_MCP_PATH` at the bundled resource dir when present (existence-guarded).
- `resolve_sidecar_command` prefers `$KALEIDO_NODE_BIN` (a Node runtime shipped with the app) over system `node`.

These are inert until the build pipeline actually bundles the provider/MCP (prod-pruned) + a per-platform Node binary into `bundle.resources` — tracked as the next step.

**Verified:** `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)