### PR TITLE
feat: add relay.kaleidoswap.com as default NWC relay

### DIFF
--- a/src-tauri/src/nwc.rs
+++ b/src-tauri/src/nwc.rs
@@ -29,7 +29,8 @@ use tauri::{AppHandle, Emitter};
 use crate::db;
 
 /// Default relays used when a connection / service doesn't specify its own.
-pub const DEFAULT_RELAYS: [&str; 3] = [
+pub const DEFAULT_RELAYS: [&str; 4] = [
+    "wss://relay.kaleidoswap.com",
     "wss://relay.damus.io",
     "wss://nos.lol",
     "wss://relay.primal.net",


### PR DESCRIPTION
Adds the KaleidoSwap-operated relay `wss://relay.kaleidoswap.com` as the primary entry in `DEFAULT_RELAYS` (`src-tauri/src/nwc.rs`), used when a NWC connection or service does not specify its own relay. Array length bumped `[&str; 3]` -> `[&str; 4]`.

The relay is open (no payment, no write restriction) and carries the desktop app's NIP-47 (Nostr Wallet Connect) traffic by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)