### PR TITLE
build(mind): scaffold packaged-build bundling for the agent sidecar

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "type-check": "tsc --noEmit",
     "preview": "vite preview",
     "tauri": "tauri",
+    "bundle:mind": "node src-tauri/scripts/prepare-mind-bundle.mjs",
     "tauri:build": "tauri build",
     "tauri:build:windows": "tauri build --target x86_64-pc-windows-msvc",
     "tauri:dev": "tauri dev",

--- a/src-tauri/.gitignore
+++ b/src-tauri/.gitignore
@@ -5,3 +5,10 @@
 
 /node_modules/
 package-lock.json
+
+# Staged KaleidoMind agent bundle (produced by scripts/prepare-mind-bundle.mjs
+# before `tauri build`) — large pruned trees + a per-platform Node binary, not
+# source. Re-generated on each packaged build. Keep the dir (Tauri's build
+# script requires the resource path to exist) but ignore its generated contents.
+/resources/mind/*
+!/resources/mind/.gitkeep

--- a/src-tauri/resources/mind/.gitkeep
+++ b/src-tauri/resources/mind/.gitkeep
@@ -1,0 +1,5 @@
+# Placeholder so `resources/mind` exists for dev/CI builds.
+#
+# `scripts/prepare-mind-bundle.mjs` populates this directory before a packaged
+# `tauri build` with provider/, mcp/, and a per-platform node binary. Those
+# generated artifacts are gitignored; this file is the only tracked content.

--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -57,7 +57,7 @@ function pruneProvider() {
   run('pnpm', ['--filter', '@kaleidorg/mind-provider', 'run', 'build'], mindRepo)
   run(
     'pnpm',
-    ['--filter', '@kaleidorg/mind-provider', 'deploy', '--prod', '--legacy', join(out, 'provider')],
+    ['--filter', '@kaleidorg/mind-provider', 'deploy', '--prod', join(out, 'provider')],
     mindRepo
   )
 }
@@ -68,10 +68,14 @@ function pruneMcp() {
   run('npm', ['run', 'build'], mcpRepo)
   const dst = join(out, 'mcp')
   mkdirSync(dst, { recursive: true })
-  for (const f of ['dist', 'package.json', 'package-lock.json']) {
+  for (const f of ['dist', 'package.json']) {
     cpSync(join(mcpRepo, f), join(dst, f), { recursive: true })
   }
-  run('npm', ['ci', '--omit=dev', '--ignore-scripts'], dst)
+  // The MCP checkout may have a lockfile generated before a local dependency
+  // bump. The packaged app consumes the manifest and freshly built dist, so
+  // resolve production dependencies from package.json instead of copying a
+  // potentially stale external lockfile into the bundle.
+  run('npm', ['install', '--omit=dev', '--ignore-scripts', '--no-package-lock'], dst)
 }
 
 // 3. Node runtime for the target platform (host by default).

--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * prepare-mind-bundle — stage the KaleidoMind agent for a PACKAGED build.
+ *
+ * Run this BEFORE `tauri build`. It produces `src-tauri/resources/mind/`:
+ *   provider/   — @kaleidorg/mind-provider, prod-pruned (the model sidecar)
+ *   mcp/        — kaleido-mcp, prod-pruned (the tool server)
+ *   node[.exe]  — a Node runtime for the TARGET platform
+ *
+ * `bundle.resources` in tauri.conf.json ships `resources/mind`, and the Rust
+ * setup hook (main.rs) points KALEIDO_MIND_PROVIDER_DIR / KALEIDO_MCP_PATH /
+ * KALEIDO_NODE_BIN at it. In dev none of this runs — the sidecar uses the
+ * sibling repos + system node.
+ *
+ * ⚠️  SCAFFOLD — must be validated with a real per-platform `tauri build`:
+ *   - The provider drags in @qvac/sdk's NATIVE modules; confirm the pruned tree
+ *     still loads the model on each target (the .node binaries are
+ *     platform-specific, so build on/for each platform).
+ *   - Confirm the bundled Node version is compatible with @qvac/sdk.
+ *   - Measure the result (`du -sh resources/mind`) — if it's too large,
+ *     esbuild-bundle the provider/mcp JS first and keep only native modules.
+ *
+ * Env knobs: NODE_VERSION (default below), MIND_REPO / MCP_REPO (sibling paths),
+ * TARGET_PLATFORM / TARGET_ARCH (override host detection for cross-builds).
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, rmSync, cpSync, chmodSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tmpdir } from 'node:os'
+
+const NODE_VERSION = process.env.NODE_VERSION ?? '20.18.1' // pin; match CI
+
+const here = dirname(fileURLToPath(import.meta.url))
+const srcTauri = resolve(here, '..')
+const repoRoot = resolve(srcTauri, '..', '..') // …/Kaleidoswap
+const mindRepo = process.env.MIND_REPO ?? join(repoRoot, 'kaleido-mind')
+const mcpRepo = process.env.MCP_REPO ?? join(repoRoot, 'kaleido-mcp')
+const out = join(srcTauri, 'resources', 'mind')
+
+// execFile (no shell) — args are passed as an array, so nothing is interpolated
+// into a command string. Safe by construction.
+const run = (cmd, args, cwd) => {
+  console.log(`$ ${cmd} ${args.join(' ')}${cwd ? `   (in ${cwd})` : ''}`)
+  execFileSync(cmd, args, { cwd, stdio: 'inherit' })
+}
+
+function reset() {
+  rmSync(out, { recursive: true, force: true })
+  mkdirSync(out, { recursive: true })
+}
+
+// 1. Provider — pnpm workspace member → `pnpm deploy --prod` gives a flat,
+//    prod-only tree (incl. the @kaleidorg/mind workspace dep + @qvac/sdk).
+function pruneProvider() {
+  if (!existsSync(mindRepo)) throw new Error(`kaleido-mind not found at ${mindRepo}`)
+  run('pnpm', ['--filter', '@kaleidorg/mind-provider', 'run', 'build'], mindRepo)
+  run(
+    'pnpm',
+    ['--filter', '@kaleidorg/mind-provider', 'deploy', '--prod', '--legacy', join(out, 'provider')],
+    mindRepo
+  )
+}
+
+// 2. MCP — standalone npm package → copy the built tree + a prod-only install.
+function pruneMcp() {
+  if (!existsSync(mcpRepo)) throw new Error(`kaleido-mcp not found at ${mcpRepo}`)
+  run('npm', ['run', 'build'], mcpRepo)
+  const dst = join(out, 'mcp')
+  mkdirSync(dst, { recursive: true })
+  for (const f of ['dist', 'package.json', 'package-lock.json']) {
+    cpSync(join(mcpRepo, f), join(dst, f), { recursive: true })
+  }
+  run('npm', ['ci', '--omit=dev', '--ignore-scripts'], dst)
+}
+
+// 3. Node runtime for the target platform (host by default).
+function fetchNode() {
+  const platMap = { darwin: 'darwin', linux: 'linux', win32: 'win' }
+  const archMap = { x64: 'x64', arm64: 'arm64' }
+  const platform = process.env.TARGET_PLATFORM ?? platMap[process.platform]
+  const arch = process.env.TARGET_ARCH ?? archMap[process.arch]
+  if (!platform || !arch) throw new Error(`unsupported target ${process.platform}/${process.arch}`)
+
+  const isWin = platform === 'win'
+  const ext = isWin ? 'zip' : 'tar.gz'
+  const base = `node-v${NODE_VERSION}-${platform}-${arch}`
+  const url = `https://nodejs.org/dist/v${NODE_VERSION}/${base}.${ext}`
+  const work = join(tmpdir(), `kaleido-node-${process.pid}`)
+  mkdirSync(work, { recursive: true })
+  const archive = join(work, `${base}.${ext}`)
+
+  run('curl', ['-fSL', url, '-o', archive])
+  // bsdtar (mac/linux/win10+) extracts both .tar.gz and .zip.
+  run('tar', ['-xf', archive, '-C', work])
+
+  const binSrc = isWin ? join(work, base, 'node.exe') : join(work, base, 'bin', 'node')
+  const binDst = join(out, isWin ? 'node.exe' : 'node')
+  cpSync(binSrc, binDst)
+  if (!isWin) chmodSync(binDst, 0o755)
+  rmSync(work, { recursive: true, force: true })
+  console.log(`node ${NODE_VERSION} ${platform}/${arch} → ${binDst}`)
+}
+
+console.log(`Staging KaleidoMind bundle → ${out}`)
+reset()
+pruneProvider()
+pruneMcp()
+fetchNode()
+console.log('\nDone. Verify size:  du -sh src-tauri/resources/mind')
+console.log('Then `tauri build` and confirm the agent runs in the packaged app.')

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -121,11 +121,7 @@ fn main() {
                 // scripts/prepare-mind-bundle.mjs); Tauri's resource layout
                 // varies by version/platform, so probe a few candidate roots.
                 if let Ok(res) = app.path().resource_dir() {
-                    for base in [
-                        res.join("mind"),
-                        res.join("resources/mind"),
-                        res.clone(),
-                    ] {
+                    for base in [res.join("mind"), res.join("resources/mind"), res.clone()] {
                         let provider = base.join("provider");
                         if provider.join("dist/index.js").exists() {
                             std::env::set_var("KALEIDO_MIND_PROVIDER_DIR", &provider);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -111,35 +111,36 @@ fn main() {
                 db::init();
 
                 // Production: point the KaleidoMind sidecar at the BUNDLED
-                // provider + MCP server (dev runs them from the sibling repos;
-                // a packaged .app/.exe has neither). mind.rs reads these env
-                // vars first (resolve_provider_dir / resolve_mcp_path) and
-                // existence-checks them, so this is a safe no-op until the
-                // `bundle.resources` actually ship these paths.
+                // provider + MCP + Node runtime (dev runs them from the sibling
+                // repos; a packaged .app/.exe has neither). mind.rs reads these
+                // env vars first (resolve_provider_dir / resolve_mcp_path /
+                // resolve_sidecar_command) and existence-checks them, so this is
+                // a safe no-op until `bundle.resources` actually ship them.
+                //
+                // The bundle lives under a `mind/` resource dir (see
+                // scripts/prepare-mind-bundle.mjs); Tauri's resource layout
+                // varies by version/platform, so probe a few candidate roots.
                 if let Ok(res) = app.path().resource_dir() {
-                    let provider = res.join("kaleido-mind/apps/provider");
-                    if provider.join("dist/index.js").exists() {
-                        std::env::set_var("KALEIDO_MIND_PROVIDER_DIR", &provider);
-                        log::info!("[mind] bundled provider dir: {}", provider.display());
-                    }
-                    let mcp = res.join("kaleido-mcp/dist/index.js");
-                    if mcp.exists() {
-                        std::env::set_var("KALEIDO_MCP_PATH", &mcp);
-                        log::info!("[mind] bundled mcp entry: {}", mcp.display());
-                    }
-                    // A Node runtime shipped with the app (so a packaged build
-                    // doesn't require system Node). Tries node[.exe] at the
-                    // resource root or under bin/.
-                    for cand in [
-                        res.join("node"),
-                        res.join("node.exe"),
-                        res.join("bin/node"),
-                        res.join("bin/node.exe"),
+                    for base in [
+                        res.join("mind"),
+                        res.join("resources/mind"),
+                        res.clone(),
                     ] {
-                        if cand.exists() {
-                            std::env::set_var("KALEIDO_NODE_BIN", &cand);
-                            log::info!("[mind] bundled node: {}", cand.display());
-                            break;
+                        let provider = base.join("provider");
+                        if provider.join("dist/index.js").exists() {
+                            std::env::set_var("KALEIDO_MIND_PROVIDER_DIR", &provider);
+                            log::info!("[mind] bundled provider: {}", provider.display());
+                        }
+                        let mcp = base.join("mcp/dist/index.js");
+                        if mcp.exists() {
+                            std::env::set_var("KALEIDO_MCP_PATH", &mcp);
+                            log::info!("[mind] bundled mcp: {}", mcp.display());
+                        }
+                        for node in [base.join("node"), base.join("node.exe")] {
+                            if node.exists() {
+                                std::env::set_var("KALEIDO_NODE_BIN", &node);
+                                log::info!("[mind] bundled node: {}", node.display());
+                            }
                         }
                     }
                 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
     "targets": "all",
     "resources": [
       "../docs",
-      "../bin/rgb-lightning-node"
+      "../bin/rgb-lightning-node",
+      "resources/mind"
     ],
     "linux": {
       "appimage": {


### PR DESCRIPTION
Follow-up to #116 (already merged). Scaffolds the production-build pipeline that ships the KaleidoMind agent inside a packaged `.app`/`.exe` — so the agent works without the user having the sibling repos or system Node.

## What this adds
- **`src-tauri/scripts/prepare-mind-bundle.mjs`** — run before `tauri build` (`pnpm bundle:mind`). Stages `src-tauri/resources/mind/`:
  - `provider/` — `@kaleidorg/mind-provider`, prod-pruned via `pnpm deploy --prod` (incl. the `@kaleidorg/mind` workspace dep + `@qvac/sdk`)
  - `mcp/` — `kaleido-mcp`, built + `npm ci --omit=dev --ignore-scripts`
  - `node[.exe]` — a per-platform Node runtime downloaded from nodejs.org
- **`tauri.conf.json`** — ships `resources/mind` via `bundle.resources`.
- **`main.rs` setup hook** — probes candidate resource roots (`mind/`, `resources/mind/`, root) and points `KALEIDO_MIND_PROVIDER_DIR` / `KALEIDO_MCP_PATH` / `KALEIDO_NODE_BIN` at the bundled tree. Existence-checked, so it's a safe no-op in dev (sidecar still uses sibling repos + system node).
- **`.gitignore` + `.gitkeep`** — generated artifacts ignored; the dir is kept so Tauri's build-time resource check passes in dev/CI.

## ⚠️ Scaffold — needs a real per-platform build to validate
Not yet exercised by an actual `tauri build`. Before relying on it:
- Confirm the pruned provider still loads the model on each target — `@qvac/sdk` has **native** `.node` modules, so build on/for each platform.
- Confirm the bundled Node version is compatible with `@qvac/sdk`.
- Measure `du -sh src-tauri/resources/mind` — if too large, esbuild-bundle the JS first and keep only native modules.

The script uses `execFileSync` (no shell). `cargo check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)