### PR TITLE
feat(mind): KaleidoMind v0.5 — agent surface, chat cards, thinking view & packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "type-check": "tsc --noEmit",
     "preview": "vite preview",
     "tauri": "tauri",
+    "bundle:mind": "node src-tauri/scripts/prepare-mind-bundle.mjs",
     "tauri:build": "tauri build",
     "tauri:build:windows": "tauri build --target x86_64-pc-windows-msvc",
     "tauri:dev": "tauri dev",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "react-router-dom": "^7.18.0",
     "react-spinners": "^0.17.0",
     "react-toastify": "^10.0.6",
+    "remark-breaks": "^4.0.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^1.14.0",
     "webfontloader": "^1.6.28",
     "zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,12 @@ importers:
       react-toastify:
         specifier: ^10.0.6
         version: 10.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwind-merge:
         specifier: ^1.14.0
         version: 1.14.0
@@ -1770,6 +1776,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-import-context@0.1.9:
     resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -2488,6 +2498,9 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2495,8 +2508,29 @@ packages:
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -2506,6 +2540,9 @@ packages:
 
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -2531,6 +2568,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -3086,11 +3144,20 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -5331,6 +5398,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-import-context@0.1.9(unrs-resolver@1.12.2):
     dependencies:
       get-tsconfig: 4.14.0
@@ -6155,6 +6224,8 @@ snapshots:
     dependencies:
       semver: 7.8.4
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
 
   md5.js@1.3.5:
@@ -6162,6 +6233,13 @@ snapshots:
       hash-base: 3.0.5
       inherits: 2.0.4
       safe-buffer: 5.2.1
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -6177,6 +6255,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6218,6 +6353,11 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
+
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
 
   mdast-util-phrasing@4.1.0:
     dependencies:
@@ -6275,6 +6415,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -6903,6 +7101,23 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -6919,6 +7134,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-from-string@2.0.2: {}
 

--- a/src-tauri/.gitignore
+++ b/src-tauri/.gitignore
@@ -5,3 +5,10 @@
 
 /node_modules/
 package-lock.json
+
+# Staged KaleidoMind agent bundle (produced by scripts/prepare-mind-bundle.mjs
+# before `tauri build`) — large pruned trees + a per-platform Node binary, not
+# source. Re-generated on each packaged build. Keep the dir (Tauri's build
+# script requires the resource path to exist) but ignore its generated contents.
+/resources/mind/*
+!/resources/mind/.gitkeep

--- a/src-tauri/resources/mind/.gitkeep
+++ b/src-tauri/resources/mind/.gitkeep
@@ -1,0 +1,5 @@
+# Placeholder so `resources/mind` exists for dev/CI builds.
+#
+# `scripts/prepare-mind-bundle.mjs` populates this directory before a packaged
+# `tauri build` with provider/, mcp/, and a per-platform node binary. Those
+# generated artifacts are gitignored; this file is the only tracked content.

--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * prepare-mind-bundle — stage the KaleidoMind agent for a PACKAGED build.
+ *
+ * Run this BEFORE `tauri build`. It produces `src-tauri/resources/mind/`:
+ *   provider/   — @kaleidorg/mind-provider, prod-pruned (the model sidecar)
+ *   mcp/        — kaleido-mcp, prod-pruned (the tool server)
+ *   node[.exe]  — a Node runtime for the TARGET platform
+ *
+ * `bundle.resources` in tauri.conf.json ships `resources/mind`, and the Rust
+ * setup hook (main.rs) points KALEIDO_MIND_PROVIDER_DIR / KALEIDO_MCP_PATH /
+ * KALEIDO_NODE_BIN at it. In dev none of this runs — the sidecar uses the
+ * sibling repos + system node.
+ *
+ * ⚠️  SCAFFOLD — must be validated with a real per-platform `tauri build`:
+ *   - The provider drags in @qvac/sdk's NATIVE modules; confirm the pruned tree
+ *     still loads the model on each target (the .node binaries are
+ *     platform-specific, so build on/for each platform).
+ *   - Confirm the bundled Node version is compatible with @qvac/sdk.
+ *   - Measure the result (`du -sh resources/mind`) — if it's too large,
+ *     esbuild-bundle the provider/mcp JS first and keep only native modules.
+ *
+ * Env knobs: NODE_VERSION (default below), MIND_REPO / MCP_REPO (sibling paths),
+ * TARGET_PLATFORM / TARGET_ARCH (override host detection for cross-builds).
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, rmSync, cpSync, chmodSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tmpdir } from 'node:os'
+
+const NODE_VERSION = process.env.NODE_VERSION ?? '20.18.1' // pin; match CI
+
+const here = dirname(fileURLToPath(import.meta.url))
+const srcTauri = resolve(here, '..')
+const repoRoot = resolve(srcTauri, '..', '..') // …/Kaleidoswap
+const mindRepo = process.env.MIND_REPO ?? join(repoRoot, 'kaleido-mind')
+const mcpRepo = process.env.MCP_REPO ?? join(repoRoot, 'kaleido-mcp')
+const out = join(srcTauri, 'resources', 'mind')
+
+// execFile (no shell) — args are passed as an array, so nothing is interpolated
+// into a command string. Safe by construction.
+const run = (cmd, args, cwd) => {
+  console.log(`$ ${cmd} ${args.join(' ')}${cwd ? `   (in ${cwd})` : ''}`)
+  execFileSync(cmd, args, { cwd, stdio: 'inherit' })
+}
+
+function reset() {
+  rmSync(out, { recursive: true, force: true })
+  mkdirSync(out, { recursive: true })
+}
+
+// 1. Provider — pnpm workspace member → `pnpm deploy --prod` gives a flat,
+//    prod-only tree (incl. the @kaleidorg/mind workspace dep + @qvac/sdk).
+function pruneProvider() {
+  if (!existsSync(mindRepo)) throw new Error(`kaleido-mind not found at ${mindRepo}`)
+  run('pnpm', ['--filter', '@kaleidorg/mind-provider', 'run', 'build'], mindRepo)
+  run(
+    'pnpm',
+    ['--filter', '@kaleidorg/mind-provider', 'deploy', '--prod', '--legacy', join(out, 'provider')],
+    mindRepo
+  )
+}
+
+// 2. MCP — standalone npm package → copy the built tree + a prod-only install.
+function pruneMcp() {
+  if (!existsSync(mcpRepo)) throw new Error(`kaleido-mcp not found at ${mcpRepo}`)
+  run('npm', ['run', 'build'], mcpRepo)
+  const dst = join(out, 'mcp')
+  mkdirSync(dst, { recursive: true })
+  for (const f of ['dist', 'package.json', 'package-lock.json']) {
+    cpSync(join(mcpRepo, f), join(dst, f), { recursive: true })
+  }
+  run('npm', ['ci', '--omit=dev', '--ignore-scripts'], dst)
+}
+
+// 3. Node runtime for the target platform (host by default).
+function fetchNode() {
+  const platMap = { darwin: 'darwin', linux: 'linux', win32: 'win' }
+  const archMap = { x64: 'x64', arm64: 'arm64' }
+  const platform = process.env.TARGET_PLATFORM ?? platMap[process.platform]
+  const arch = process.env.TARGET_ARCH ?? archMap[process.arch]
+  if (!platform || !arch) throw new Error(`unsupported target ${process.platform}/${process.arch}`)
+
+  const isWin = platform === 'win'
+  const ext = isWin ? 'zip' : 'tar.gz'
+  const base = `node-v${NODE_VERSION}-${platform}-${arch}`
+  const url = `https://nodejs.org/dist/v${NODE_VERSION}/${base}.${ext}`
+  const work = join(tmpdir(), `kaleido-node-${process.pid}`)
+  mkdirSync(work, { recursive: true })
+  const archive = join(work, `${base}.${ext}`)
+
+  run('curl', ['-fSL', url, '-o', archive])
+  // bsdtar (mac/linux/win10+) extracts both .tar.gz and .zip.
+  run('tar', ['-xf', archive, '-C', work])
+
+  const binSrc = isWin ? join(work, base, 'node.exe') : join(work, base, 'bin', 'node')
+  const binDst = join(out, isWin ? 'node.exe' : 'node')
+  cpSync(binSrc, binDst)
+  if (!isWin) chmodSync(binDst, 0o755)
+  rmSync(work, { recursive: true, force: true })
+  console.log(`node ${NODE_VERSION} ${platform}/${arch} → ${binDst}`)
+}
+
+console.log(`Staging KaleidoMind bundle → ${out}`)
+reset()
+pruneProvider()
+pruneMcp()
+fetchNode()
+console.log('\nDone. Verify size:  du -sh src-tauri/resources/mind')
+console.log('Then `tauri build` and confirm the agent runs in the packaged app.')

--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -24,7 +24,14 @@
  * TARGET_PLATFORM / TARGET_ARCH (override host detection for cross-builds).
  */
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, rmSync, cpSync, chmodSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  cpSync,
+  chmodSync,
+  writeFileSync,
+} from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
@@ -42,12 +49,22 @@ const out = join(srcTauri, 'resources', 'mind')
 // into a command string. Safe by construction.
 const run = (cmd, args, cwd) => {
   console.log(`$ ${cmd} ${args.join(' ')}${cwd ? `   (in ${cwd})` : ''}`)
-  execFileSync(cmd, args, { cwd, stdio: 'inherit' })
+  const env = { ...process.env }
+  // pnpm-only: the sibling repos pin an older packageManager (kaleido-mind →
+  // pnpm@9.0.0) and `deploy --legacy` only exists in pnpm ≥9.4. Disable pnpm's
+  // version switching so the host pnpm (which supports --legacy — the only
+  // deploy mode that yields a self-contained node_modules) runs regardless of
+  // each sibling's pin. Scoped to pnpm so npm doesn't warn on an unknown config.
+  if (cmd === 'pnpm') env.npm_config_manage_package_manager_versions = 'false'
+  execFileSync(cmd, args, { cwd, stdio: 'inherit', env })
 }
 
 function reset() {
   rmSync(out, { recursive: true, force: true })
   mkdirSync(out, { recursive: true })
+  // Restore the tracked placeholder so the dir survives in git — Tauri's
+  // build-time resource check needs resources/mind to exist in dev/CI.
+  writeFileSync(join(out, '.gitkeep'), '')
 }
 
 // 1. Provider — pnpm workspace member → `pnpm deploy --prod` gives a flat,
@@ -71,7 +88,16 @@ function pruneMcp() {
   for (const f of ['dist', 'package.json', 'package-lock.json']) {
     cpSync(join(mcpRepo, f), join(dst, f), { recursive: true })
   }
-  run('npm', ['ci', '--omit=dev', '--ignore-scripts'], dst)
+  // Prefer a reproducible `npm ci`, but kaleido-mcp's committed lockfile can
+  // lag its package.json (e.g. a stale kaleido-sdk pin); fall back to
+  // `npm install` so sibling lockfile drift doesn't break the bundle.
+  const npmArgs = ['--omit=dev', '--ignore-scripts', '--no-audit', '--no-fund']
+  try {
+    run('npm', ['ci', ...npmArgs], dst)
+  } catch {
+    console.warn('  npm ci failed (lockfile drift?) — retrying with npm install')
+    run('npm', ['install', ...npmArgs], dst)
+  }
 }
 
 // 3. Node runtime for the target platform (host by default).

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -121,11 +121,7 @@ fn main() {
                 // scripts/prepare-mind-bundle.mjs); Tauri's resource layout
                 // varies by version/platform, so probe a few candidate roots.
                 if let Ok(res) = app.path().resource_dir() {
-                    for base in [
-                        res.join("mind"),
-                        res.join("resources/mind"),
-                        res.clone(),
-                    ] {
+                    for base in [res.join("mind"), res.join("resources/mind"), res.clone()] {
                         let provider = base.join("provider");
                         if provider.join("dist/index.js").exists() {
                             std::env::set_var("KALEIDO_MIND_PROVIDER_DIR", &provider);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -111,35 +111,36 @@ fn main() {
                 db::init();
 
                 // Production: point the KaleidoMind sidecar at the BUNDLED
-                // provider + MCP server (dev runs them from the sibling repos;
-                // a packaged .app/.exe has neither). mind.rs reads these env
-                // vars first (resolve_provider_dir / resolve_mcp_path) and
-                // existence-checks them, so this is a safe no-op until the
-                // `bundle.resources` actually ship these paths.
+                // provider + MCP + Node runtime (dev runs them from the sibling
+                // repos; a packaged .app/.exe has neither). mind.rs reads these
+                // env vars first (resolve_provider_dir / resolve_mcp_path /
+                // resolve_sidecar_command) and existence-checks them, so this is
+                // a safe no-op until `bundle.resources` actually ship them.
+                //
+                // The bundle lives under a `mind/` resource dir (see
+                // scripts/prepare-mind-bundle.mjs); Tauri's resource layout
+                // varies by version/platform, so probe a few candidate roots.
                 if let Ok(res) = app.path().resource_dir() {
-                    let provider = res.join("kaleido-mind/apps/provider");
-                    if provider.join("dist/index.js").exists() {
-                        std::env::set_var("KALEIDO_MIND_PROVIDER_DIR", &provider);
-                        log::info!("[mind] bundled provider dir: {}", provider.display());
-                    }
-                    let mcp = res.join("kaleido-mcp/dist/index.js");
-                    if mcp.exists() {
-                        std::env::set_var("KALEIDO_MCP_PATH", &mcp);
-                        log::info!("[mind] bundled mcp entry: {}", mcp.display());
-                    }
-                    // A Node runtime shipped with the app (so a packaged build
-                    // doesn't require system Node). Tries node[.exe] at the
-                    // resource root or under bin/.
-                    for cand in [
-                        res.join("node"),
-                        res.join("node.exe"),
-                        res.join("bin/node"),
-                        res.join("bin/node.exe"),
+                    for base in [
+                        res.join("mind"),
+                        res.join("resources/mind"),
+                        res.clone(),
                     ] {
-                        if cand.exists() {
-                            std::env::set_var("KALEIDO_NODE_BIN", &cand);
-                            log::info!("[mind] bundled node: {}", cand.display());
-                            break;
+                        let provider = base.join("provider");
+                        if provider.join("dist/index.js").exists() {
+                            std::env::set_var("KALEIDO_MIND_PROVIDER_DIR", &provider);
+                            log::info!("[mind] bundled provider: {}", provider.display());
+                        }
+                        let mcp = base.join("mcp/dist/index.js");
+                        if mcp.exists() {
+                            std::env::set_var("KALEIDO_MCP_PATH", &mcp);
+                            log::info!("[mind] bundled mcp: {}", mcp.display());
+                        }
+                        for node in [base.join("node"), base.join("node.exe")] {
+                            if node.exists() {
+                                std::env::set_var("KALEIDO_NODE_BIN", &node);
+                                log::info!("[mind] bundled node: {}", node.display());
+                            }
                         }
                     }
                 }

--- a/src-tauri/src/mind.rs
+++ b/src-tauri/src/mind.rs
@@ -75,6 +75,20 @@ impl MindProcess {
             cmd.current_dir(dir);
         }
 
+        // The desktop wallet is backed by RLN only. Keep legacy WDK/Spark
+        // aliases out of the model's tool prompt so small local models do not
+        // waste tokens choosing between duplicate wallet implementations.
+        cmd.env("KALEIDO_MIND_RLN_ONLY", "1");
+
+        // Conservative desktop defaults for local reasoning. Users can still
+        // override these through the inherited environment or Agent settings.
+        if std::env::var_os("KALEIDO_MIND_MAX_THINKING_TOKENS").is_none() {
+            cmd.env("KALEIDO_MIND_MAX_THINKING_TOKENS", "128");
+        }
+        if std::env::var_os("KALEIDO_MIND_MAX_TOKENS").is_none() {
+            cmd.env("KALEIDO_MIND_MAX_TOKENS", "512");
+        }
+
         // Point the sidecar at kaleido-mcp so the agent gets real tools.
         // Without KALEIDO_MCP_PATH the provider runs "tool-less" — the model
         // narrates tool calls ("I'll check your balance…") it can never execute.
@@ -105,6 +119,27 @@ impl MindProcess {
         {
             log::info!("[mind] RLN_NODE_URL={}", url);
             cmd.env("RLN_NODE_URL", url);
+        }
+
+        // Point the MCP at the SAME maker the trading UI uses. kaleido-mcp
+        // defaults to mainnet api.kaleidoswap.com, which doesn't resolve on the
+        // test networks (signet/regtest) — so without this the LSP + swap tools
+        // "fetch failed". Source it from the active account's default_maker_url
+        // (e.g. https://api.signet.kaleidoswap.com), trimming any trailing slash
+        // so the SDK's "/api/v1/lsps1/*" paths don't double up.
+        if let Some(url) = app
+            .try_state::<crate::CurrentAccount>()
+            .and_then(|acc| {
+                acc.0
+                    .read()
+                    .ok()
+                    .and_then(|g| g.as_ref().map(|a| a.default_maker_url.clone()))
+            })
+            .map(|u| u.trim().trim_end_matches('/').to_string())
+            .filter(|u| !u.is_empty())
+        {
+            log::info!("[mind] KALEIDOSWAP_API_URL={}", url);
+            cmd.env("KALEIDOSWAP_API_URL", url);
         }
 
         let mut child = cmd

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
     "targets": "all",
     "resources": [
       "../docs",
-      "../bin/rgb-lightning-node"
+      "../bin/rgb-lightning-node",
+      "resources/mind"
     ],
     "linux": {
       "appimage": {

--- a/src/api/mind.ts
+++ b/src/api/mind.ts
@@ -100,6 +100,8 @@ export type MindEvent =
 
 export interface ChatResult {
   text: string
+  /** The model's `<think>` reasoning for this turn, if any (shown collapsed in chat). */
+  thinking?: string
   latencyMs: number
   tokensPerSecond: number
 }

--- a/src/api/mind.ts
+++ b/src/api/mind.ts
@@ -107,6 +107,112 @@ export interface ToolConfirmRequestEvent {
   timeoutMs: number
 }
 
+// ── Autonomy types (mirror apps/provider/src/protocol.ts) ────────────────
+
+export interface TaskAllocation {
+  btcSat: number
+  usdt: number
+  xaut: number
+}
+
+export interface AgentTask {
+  id: string
+  name: string
+  description: string
+  skill: string
+  scheduleSec: number
+  runOnStartup: boolean
+  allocation: TaskAllocation
+  enabled: boolean
+  createdAt: number
+  lastRunAt: number | null
+}
+
+export interface RiskLimits {
+  dryRun: boolean
+  minBtcReserveSat: number
+  stopLossBtcSat: number
+  maxSpendUsd: number
+  autoApproveUnderUsd: number
+  maxOpenOrders?: number
+}
+
+export interface PortfolioTargets {
+  btcPct: number
+  usdtPct: number
+  xautPct: number
+  driftThresholdPct: number
+}
+
+export interface TaskRunCost {
+  usd: number
+  inputTokens: number
+  outputTokens: number
+}
+
+export interface TaskStats {
+  runs: number
+  errors: number
+  lastRunAt: number | null
+  lastDurationMs: number | null
+  lastToolCalls: number | null
+  lastError: string | null
+  lastText: string | null
+}
+
+export interface TaskRunRecord {
+  taskId: string
+  taskName: string
+  startedAt: number
+  durationMs: number
+  toolCalls: number
+  ok: boolean
+  error: string | null
+  text: string
+  cost: TaskRunCost
+}
+
+export interface AgentState {
+  schedulerRunning: boolean
+  risk: RiskLimits
+  targets: PortfolioTargets
+  /** Generation token caps (0 ⇒ uncapped). */
+  generation: { maxThinkingTokens: number; maxOutputTokens: number }
+  recent: TaskRunRecord[]
+  stats: Record<string, TaskStats>
+  cumulative: TaskRunCost
+}
+
+export interface SuggestedAction {
+  id: string
+  /** 'wallet' | 'node' | 'portfolio' | 'trade' — mapped to an icon by the UI. */
+  icon: string
+  title: string
+  subtitle: string
+  prompt: string
+}
+
+export interface NewTaskInput {
+  name: string
+  description: string
+  skill: string
+  scheduleSec: number
+  enabled: boolean
+  runOnStartup?: boolean
+  allocation?: TaskAllocation
+  id?: string
+}
+
+export interface TaskPatchInput {
+  name?: string
+  description?: string
+  skill?: string
+  scheduleSec?: number
+  runOnStartup?: boolean
+  allocation?: TaskAllocation
+  enabled?: boolean
+}
+
 export type MindEvent =
   | { type: 'ready'; version: string }
   | ProviderStatusEvent
@@ -117,7 +223,37 @@ export type MindEvent =
   | { type: 'peer_disconnected'; shortKey: string }
   | { type: 'download_progress'; progress: DownloadProgress }
   | { type: 'download_completed'; modelId: string }
+  | { type: 'chat_thinking_delta'; chatId: string; delta: string }
+  | { type: 'chat_content_delta'; chatId: string; delta: string }
+  | {
+      type: 'chat_tool_call'
+      chatId: string
+      id: string
+      name: string
+      arguments: Record<string, unknown>
+      requiresConfirmation?: boolean
+    }
+  | {
+      type: 'chat_tool_result'
+      chatId: string
+      id: string
+      name: string
+      arguments: Record<string, unknown>
+      ok: boolean
+      result: unknown
+    }
   | { type: 'capabilities_changed'; capabilities: CapabilityInfo }
+  | { type: 'tasks_changed'; tasks: AgentTask[] }
+  | { type: 'task_run_started'; taskId: string; taskName: string; at: number }
+  | { type: 'task_run_finished'; record: TaskRunRecord }
+  | { type: 'agent_state'; state: AgentState }
+  | {
+      type: 'agent_message'
+      text: string
+      taskId?: string
+      taskName?: string
+      at: number
+    }
   | { type: 'log'; level: 'debug' | 'info' | 'warn' | 'error'; message: string }
   | { type: 'response'; id: string; ok: true; data?: unknown }
   | { type: 'response'; id: string; ok: false; error: string }
@@ -129,6 +265,39 @@ export interface ChatResult {
   thinking?: string
   latencyMs: number
   tokensPerSecond: number
+  /** Total tokens this turn (prompt + completion), from QVAC stats. */
+  tokens?: number
+  promptTokens?: number
+  /** The backend that actually ran this response. */
+  device?: 'gpu' | 'cpu' | null
+  /** Contextual next-step cards the agent proposes after this reply. */
+  followups?: SuggestedAction[]
+}
+
+/** A tool the agent invoked mid-turn (drives the live "running" pill). */
+export interface ChatToolCall {
+  id: string
+  name: string
+  arguments: Record<string, unknown>
+  requiresConfirmation?: boolean
+}
+
+/** A tool's result (drives the typed result card). */
+export interface ChatToolResult {
+  id: string
+  name: string
+  arguments: Record<string, unknown>
+  ok: boolean
+  result: unknown
+}
+
+export interface ChatHandlers {
+  onThinking?: (delta: string) => void
+  onToken?: (delta: string) => void
+  /** The agent started a tool call (before it executes). */
+  onToolCall?: (call: ChatToolCall) => void
+  /** A tool returned (after it executes). */
+  onToolResult?: (result: ChatToolResult) => void
 }
 
 type EventHandler = (e: MindEvent) => void
@@ -250,12 +419,11 @@ class MindClient {
   downloadModel(modelId: string) {
     return this.send({ cmd: 'download_model', modelId })
   }
-  addHuggingFaceModel(repo: string, file: string, displayName?: string) {
+  addHuggingFaceModel(url: string, displayName?: string) {
     return this.request<CatalogModel>({
       cmd: 'add_huggingface_model',
       displayName,
-      file,
-      repo,
+      url,
     })
   }
   cancelDownload(modelId: string) {
@@ -271,9 +439,38 @@ class MindClient {
   stopProvider() {
     return this.request<ProviderStatusEvent>({ cmd: 'stop' })
   }
-  chat(prompt: string) {
+  chat(prompt: string, handlers?: ChatHandlers) {
     // Generous: an agentic run may pause up to 120s on a tool confirmation.
-    return this.request<ChatResult>({ cmd: 'chat', prompt }, 300_000)
+    const chatId = crypto.randomUUID()
+    const off = this.on((event) => {
+      if (event.type === 'chat_thinking_delta' && event.chatId === chatId) {
+        handlers?.onThinking?.(event.delta)
+      } else if (
+        event.type === 'chat_content_delta' &&
+        event.chatId === chatId
+      ) {
+        handlers?.onToken?.(event.delta)
+      } else if (event.type === 'chat_tool_call' && event.chatId === chatId) {
+        handlers?.onToolCall?.({
+          arguments: event.arguments,
+          id: event.id,
+          name: event.name,
+          requiresConfirmation: event.requiresConfirmation,
+        })
+      } else if (event.type === 'chat_tool_result' && event.chatId === chatId) {
+        handlers?.onToolResult?.({
+          arguments: event.arguments,
+          id: event.id,
+          name: event.name,
+          ok: event.ok,
+          result: event.result,
+        })
+      }
+    })
+    return this.request<ChatResult>(
+      { chatId, cmd: 'chat', prompt },
+      300_000
+    ).finally(off)
   }
   listCapabilities() {
     return this.request<CapabilityInfo>({ cmd: 'list_capabilities' })
@@ -284,6 +481,23 @@ class MindClient {
       enabled,
       name,
     })
+  }
+  addSkill(
+    name: string,
+    description: string,
+    instructions: string,
+    tools?: string[]
+  ) {
+    return this.request<CapabilityInfo>({
+      cmd: 'add_skill',
+      description,
+      instructions,
+      name,
+      tools,
+    })
+  }
+  deleteSkill(name: string) {
+    return this.request<CapabilityInfo>({ cmd: 'delete_skill', name })
   }
   addMcpServer(name: string, url: string) {
     return this.request<CapabilityInfo>({
@@ -301,6 +515,50 @@ class MindClient {
   /** Answer a tool_confirm_request (approve/decline a pending spend). */
   confirmTool(confirmId: string, approved: boolean, reason?: string) {
     return this.send({ approved, cmd: 'tool_confirm', confirmId, reason })
+  }
+
+  // ── Autonomy (the agent's task brain) ──────────────────────────────
+  listTasks() {
+    return this.request<AgentTask[]>({ cmd: 'list_tasks' })
+  }
+  createTask(task: NewTaskInput) {
+    return this.request<AgentTask>({ cmd: 'create_task', task })
+  }
+  updateTask(taskId: string, patch: TaskPatchInput) {
+    return this.request<AgentTask | null>({ cmd: 'update_task', patch, taskId })
+  }
+  deleteTask(taskId: string) {
+    return this.request<{ removed: boolean }>({ cmd: 'delete_task', taskId })
+  }
+  /** Force-run a task now (regardless of schedule). Resolves with its outcome. */
+  runTask(taskId: string) {
+    return this.request<{
+      ok: boolean
+      text?: string
+      toolCalls?: number
+      error?: string
+    } | null>({ cmd: 'run_task', taskId }, 300_000)
+  }
+  setScheduler(running: boolean) {
+    return this.request<AgentState>({ cmd: 'set_scheduler', running })
+  }
+  getAgentState() {
+    return this.request<AgentState>({ cmd: 'get_agent_state' })
+  }
+  setRiskLimits(limits: Partial<RiskLimits>) {
+    return this.request<AgentState>({ cmd: 'set_risk_limits', limits })
+  }
+  setPortfolioTargets(targets: Partial<PortfolioTargets>) {
+    return this.request<AgentState>({ cmd: 'set_portfolio_targets', targets })
+  }
+  setGenerationLimits(limits: {
+    maxThinkingTokens?: number
+    maxOutputTokens?: number
+  }) {
+    return this.request<AgentState>({ cmd: 'set_generation_limits', ...limits })
+  }
+  getSuggestedActions() {
+    return this.request<SuggestedAction[]>({ cmd: 'get_suggested_actions' })
   }
 }
 

--- a/src/api/mind.ts
+++ b/src/api/mind.ts
@@ -26,6 +26,30 @@ export interface ProviderStatusEvent {
   peers: PeerInfo[]
   tokensPerSecond: number | null
   startedAt: number | null
+  inferenceDevice?: 'gpu' | 'cpu' | 'mock' | null
+}
+
+export interface CapabilityInfo {
+  skills: Array<{
+    name: string
+    description: string
+    enabled: boolean
+    tools: string[]
+  }>
+  tools: Array<{
+    name: string
+    description: string
+    requiresConfirmation: boolean
+  }>
+  mcpConnected: boolean
+  mcpServers: Array<{
+    id: string
+    name: string
+    url: string
+    connected: boolean
+    toolCount: number
+    error?: string
+  }>
 }
 
 export interface InstalledModel {
@@ -93,6 +117,7 @@ export type MindEvent =
   | { type: 'peer_disconnected'; shortKey: string }
   | { type: 'download_progress'; progress: DownloadProgress }
   | { type: 'download_completed'; modelId: string }
+  | { type: 'capabilities_changed'; capabilities: CapabilityInfo }
   | { type: 'log'; level: 'debug' | 'info' | 'warn' | 'error'; message: string }
   | { type: 'response'; id: string; ok: true; data?: unknown }
   | { type: 'response'; id: string; ok: false; error: string }
@@ -225,6 +250,14 @@ class MindClient {
   downloadModel(modelId: string) {
     return this.send({ cmd: 'download_model', modelId })
   }
+  addHuggingFaceModel(repo: string, file: string, displayName?: string) {
+    return this.request<CatalogModel>({
+      cmd: 'add_huggingface_model',
+      displayName,
+      file,
+      repo,
+    })
+  }
   cancelDownload(modelId: string) {
     return this.send({ cmd: 'cancel_download', modelId })
   }
@@ -241,6 +274,29 @@ class MindClient {
   chat(prompt: string) {
     // Generous: an agentic run may pause up to 120s on a tool confirmation.
     return this.request<ChatResult>({ cmd: 'chat', prompt }, 300_000)
+  }
+  listCapabilities() {
+    return this.request<CapabilityInfo>({ cmd: 'list_capabilities' })
+  }
+  setSkillEnabled(name: string, enabled: boolean) {
+    return this.request<CapabilityInfo>({
+      cmd: 'set_skill_enabled',
+      enabled,
+      name,
+    })
+  }
+  addMcpServer(name: string, url: string) {
+    return this.request<CapabilityInfo>({
+      cmd: 'add_mcp_server',
+      name,
+      url,
+    })
+  }
+  removeMcpServer(id: string) {
+    return this.request<CapabilityInfo>({
+      cmd: 'remove_mcp_server',
+      serverId: id,
+    })
   }
   /** Answer a tool_confirm_request (approve/decline a pending spend). */
   confirmTool(confirmId: string, approved: boolean, reason?: string) {

--- a/src/app/router/index.tsx
+++ b/src/app/router/index.tsx
@@ -29,10 +29,12 @@ import {
   WALLET_HISTORY_CHANNEL_ORDERS_PATH,
   CREATEUTXOS_PATH,
   KALEIDO_MIND_PATH,
+  KALEIDO_MIND_BRAIN_PATH,
   KALEIDO_MIND_PAIRING_PATH,
   KALEIDO_MIND_MODELS_PATH,
   KALEIDO_MIND_SKILLS_PATH,
   KALEIDO_MIND_CHAT_PATH,
+  KALEIDO_MIND_AGENT_PATH,
 } from './paths'
 
 export const router = createBrowserRouter([
@@ -136,7 +138,15 @@ export const router = createBrowserRouter([
         children: [
           {
             index: true,
+            lazy: () => import('../../routes/kaleido-mind/chat'),
+          },
+          {
+            lazy: () => import('../../routes/kaleido-mind/chat'),
+            path: KALEIDO_MIND_CHAT_PATH,
+          },
+          {
             lazy: () => import('../../routes/kaleido-mind/brain'),
+            path: KALEIDO_MIND_BRAIN_PATH,
           },
           {
             lazy: () => import('../../routes/kaleido-mind/pairing'),
@@ -151,8 +161,8 @@ export const router = createBrowserRouter([
             path: KALEIDO_MIND_SKILLS_PATH,
           },
           {
-            lazy: () => import('../../routes/kaleido-mind/chat'),
-            path: KALEIDO_MIND_CHAT_PATH,
+            lazy: () => import('../../routes/kaleido-mind/agent'),
+            path: KALEIDO_MIND_AGENT_PATH,
           },
         ],
         lazy: () => import('../../routes/kaleido-mind'),

--- a/src/app/router/paths.ts
+++ b/src/app/router/paths.ts
@@ -65,6 +65,9 @@ export const ORDER_CHANNEL_PATH = makePath(['order-new-channel'])
 export const CREATEUTXOS_PATH = makePath(['createutxos'])
 
 export const KALEIDO_MIND_PATH = makePath(['kaleido-mind'])
+// Chat is the landing view (index of /kaleido-mind). The Brain overview moved to
+// its own path so chat gets top billing.
+export const KALEIDO_MIND_BRAIN_PATH = makePath([KALEIDO_MIND_PATH, 'brain'])
 export const KALEIDO_MIND_PAIRING_PATH = makePath([
   KALEIDO_MIND_PATH,
   'pairing',
@@ -72,3 +75,4 @@ export const KALEIDO_MIND_PAIRING_PATH = makePath([
 export const KALEIDO_MIND_MODELS_PATH = makePath([KALEIDO_MIND_PATH, 'models'])
 export const KALEIDO_MIND_SKILLS_PATH = makePath([KALEIDO_MIND_PATH, 'skills'])
 export const KALEIDO_MIND_CHAT_PATH = makePath([KALEIDO_MIND_PATH, 'chat'])
+export const KALEIDO_MIND_AGENT_PATH = makePath([KALEIDO_MIND_PATH, 'agent'])

--- a/src/components/Layout/config.tsx
+++ b/src/components/Layout/config.tsx
@@ -18,12 +18,10 @@ import {
   HardDriveDownload,
   Target,
   Link as LinkIcon,
+  Bot,
   Brain,
   Droplets,
   Tag,
-  QrCode,
-  Cpu,
-  Sparkles,
   ArrowLeftRight,
   Radio,
   LayoutDashboard,
@@ -57,10 +55,8 @@ import {
   CREATE_NEW_CHANNEL_PATH,
   ORDER_CHANNEL_PATH,
   KALEIDO_MIND_PATH,
-  KALEIDO_MIND_PAIRING_PATH,
-  KALEIDO_MIND_MODELS_PATH,
-  KALEIDO_MIND_SKILLS_PATH,
-  KALEIDO_MIND_CHAT_PATH,
+  KALEIDO_MIND_BRAIN_PATH,
+  KALEIDO_MIND_AGENT_PATH,
 } from '../../app/router/paths'
 
 // Define types for navigation items
@@ -175,29 +171,20 @@ export const getNavSections = (t: TFunction): NavSection[] => [
         matchPath: KALEIDO_MIND_PATH,
         subMenu: [
           {
-            icon: <LayoutDashboard className="w-4 h-4" />,
-            label: t('navigation.overview', 'Overview'),
+            icon: <MessageSquare className="w-4 h-4" />,
+            label: t('navigation.chat', 'Chat'),
             to: KALEIDO_MIND_PATH,
           },
           {
-            icon: <QrCode className="w-4 h-4" />,
-            label: t('navigation.pairing', 'Pairing'),
-            to: KALEIDO_MIND_PAIRING_PATH,
+            icon: <Bot className="w-4 h-4" />,
+            label: t('navigation.agent', 'Agent'),
+            to: KALEIDO_MIND_AGENT_PATH,
           },
           {
-            icon: <Cpu className="w-4 h-4" />,
-            label: t('navigation.models', 'Models'),
-            to: KALEIDO_MIND_MODELS_PATH,
-          },
-          {
-            icon: <Sparkles className="w-4 h-4" />,
-            label: t('navigation.skills', 'Skills'),
-            to: KALEIDO_MIND_SKILLS_PATH,
-          },
-          {
-            icon: <MessageSquare className="w-4 h-4" />,
-            label: t('navigation.chat', 'Chat'),
-            to: KALEIDO_MIND_CHAT_PATH,
+            // Brain hosts Models + Skills management inline.
+            icon: <LayoutDashboard className="w-4 h-4" />,
+            label: t('navigation.brain', 'Brain'),
+            to: KALEIDO_MIND_BRAIN_PATH,
           },
         ],
         to: KALEIDO_MIND_PATH,

--- a/src/hooks/useMind.ts
+++ b/src/hooks/useMind.ts
@@ -10,6 +10,8 @@ import {
   mindClient,
   type CatalogModel,
   type CapabilityInfo,
+  type ChatHandlers,
+  type ChatResult,
   type InstalledModel,
   type MindEvent,
   type ProviderLoadingEvent,
@@ -35,15 +37,18 @@ export interface UseMindResult {
   downloadModel: (modelId: string) => Promise<void>
   cancelDownload: (modelId: string) => Promise<void>
   deleteModel: (modelId: string) => Promise<void>
-  addHuggingFaceModel: (
-    repo: string,
-    file: string,
-    displayName?: string
-  ) => Promise<void>
+  addHuggingFaceModel: (url: string, displayName?: string) => Promise<void>
   setSkillEnabled: (name: string, enabled: boolean) => Promise<void>
+  addSkill: (
+    name: string,
+    description: string,
+    instructions: string,
+    tools?: string[]
+  ) => Promise<void>
+  deleteSkill: (name: string) => Promise<void>
   addMcpServer: (name: string, url: string) => Promise<void>
   removeMcpServer: (id: string) => Promise<void>
-  chat: (prompt: string) => Promise<{ text: string; thinking?: string }>
+  chat: (prompt: string, handlers?: ChatHandlers) => Promise<ChatResult>
   /** Approve or decline the pending spend. */
   respondConfirm: (approved: boolean, reason?: string) => Promise<void>
 }
@@ -189,12 +194,8 @@ export function useMind(): UseMindResult {
   )
 
   const addHuggingFaceModel = useCallback(
-    async (repo: string, file: string, displayName?: string) => {
-      const model = await mindClient.addHuggingFaceModel(
-        repo,
-        file,
-        displayName
-      )
+    async (url: string, displayName?: string) => {
+      const model = await mindClient.addHuggingFaceModel(url, displayName)
       setCatalog(await mindClient.listCatalogModels())
       setDownloads((d) => ({ ...d, [model.id]: 0 }))
     },
@@ -208,6 +209,24 @@ export function useMind(): UseMindResult {
     []
   )
 
+  const addSkill = useCallback(
+    async (
+      name: string,
+      description: string,
+      instructions: string,
+      tools?: string[]
+    ) => {
+      setCapabilities(
+        await mindClient.addSkill(name, description, instructions, tools)
+      )
+    },
+    []
+  )
+
+  const deleteSkill = useCallback(async (name: string) => {
+    setCapabilities(await mindClient.deleteSkill(name))
+  }, [])
+
   const addMcpServer = useCallback(async (name: string, url: string) => {
     setCapabilities(await mindClient.addMcpServer(name, url))
   }, [])
@@ -216,9 +235,8 @@ export function useMind(): UseMindResult {
     setCapabilities(await mindClient.removeMcpServer(id))
   }, [])
 
-  const chat = useCallback(async (prompt: string) => {
-    const res = await mindClient.chat(prompt)
-    return { text: res.text, thinking: res.thinking }
+  const chat = useCallback(async (prompt: string, handlers?: ChatHandlers) => {
+    return mindClient.chat(prompt, handlers)
   }, [])
 
   const respondConfirm = useCallback(
@@ -236,11 +254,13 @@ export function useMind(): UseMindResult {
   return {
     addHuggingFaceModel,
     addMcpServer,
+    addSkill,
     cancelDownload,
     capabilities,
     catalog,
     chat,
     deleteModel,
+    deleteSkill,
     downloadModel,
     downloads,
     installed,

--- a/src/hooks/useMind.ts
+++ b/src/hooks/useMind.ts
@@ -33,7 +33,7 @@ export interface UseMindResult {
   downloadModel: (modelId: string) => Promise<void>
   cancelDownload: (modelId: string) => Promise<void>
   deleteModel: (modelId: string) => Promise<void>
-  chat: (prompt: string) => Promise<string>
+  chat: (prompt: string) => Promise<{ text: string; thinking?: string }>
   /** Approve or decline the pending spend. */
   respondConfirm: (approved: boolean, reason?: string) => Promise<void>
 }
@@ -173,7 +173,7 @@ export function useMind(): UseMindResult {
 
   const chat = useCallback(async (prompt: string) => {
     const res = await mindClient.chat(prompt)
-    return res.text
+    return { text: res.text, thinking: res.thinking }
   }, [])
 
   const respondConfirm = useCallback(

--- a/src/hooks/useMind.ts
+++ b/src/hooks/useMind.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   mindClient,
   type CatalogModel,
+  type CapabilityInfo,
   type InstalledModel,
   type MindEvent,
   type ProviderLoadingEvent,
@@ -26,6 +27,7 @@ export interface UseMindResult {
   ready: boolean
   /** A spend awaiting the user's approval (null when none). */
   pendingConfirm: ToolConfirmRequestEvent | null
+  capabilities: CapabilityInfo | null
   // actions
   refresh: () => Promise<void>
   startProvider: (modelId: string) => Promise<void>
@@ -33,6 +35,14 @@ export interface UseMindResult {
   downloadModel: (modelId: string) => Promise<void>
   cancelDownload: (modelId: string) => Promise<void>
   deleteModel: (modelId: string) => Promise<void>
+  addHuggingFaceModel: (
+    repo: string,
+    file: string,
+    displayName?: string
+  ) => Promise<void>
+  setSkillEnabled: (name: string, enabled: boolean) => Promise<void>
+  addMcpServer: (name: string, url: string) => Promise<void>
+  removeMcpServer: (id: string) => Promise<void>
   chat: (prompt: string) => Promise<{ text: string; thinking?: string }>
   /** Approve or decline the pending spend. */
   respondConfirm: (approved: boolean, reason?: string) => Promise<void>
@@ -49,6 +59,7 @@ export function useMind(): UseMindResult {
   const [logs, setLogs] = useState<string[]>([])
   const [pendingConfirm, setPendingConfirm] =
     useState<ToolConfirmRequestEvent | null>(null)
+  const [capabilities, setCapabilities] = useState<CapabilityInfo | null>(null)
   // Auto-clear the confirm card when the sidecar's timeout declines it.
   const confirmTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -63,14 +74,16 @@ export function useMind(): UseMindResult {
   const refresh = useCallback(async () => {
     try {
       await mindClient.start()
-      const [cat, inst, st] = await Promise.all([
+      const [cat, inst, st, caps] = await Promise.all([
         mindClient.listCatalogModels(),
         mindClient.listInstalledModels(),
         mindClient.getStatus(),
+        mindClient.listCapabilities(),
       ])
       setCatalog(cat)
       setInstalled(inst)
       setStatus(st)
+      setCapabilities(caps)
     } catch {
       /* sidecar may still be booting */
     }
@@ -113,6 +126,9 @@ export function useMind(): UseMindResult {
           })
           void refreshInstalledRef.current()
           break
+        case 'capabilities_changed':
+          setCapabilities(e.capabilities)
+          break
         case 'tool_confirm_request':
           setPendingConfirm(e)
           if (confirmTimer.current) clearTimeout(confirmTimer.current)
@@ -142,6 +158,7 @@ export function useMind(): UseMindResult {
   const startProvider = useCallback(async (modelId: string) => {
     const st = await mindClient.startProvider(modelId)
     setStatus(st)
+    setCapabilities(await mindClient.listCapabilities())
   }, [])
 
   const stopProvider = useCallback(async () => {
@@ -171,6 +188,34 @@ export function useMind(): UseMindResult {
     [refreshInstalled]
   )
 
+  const addHuggingFaceModel = useCallback(
+    async (repo: string, file: string, displayName?: string) => {
+      const model = await mindClient.addHuggingFaceModel(
+        repo,
+        file,
+        displayName
+      )
+      setCatalog(await mindClient.listCatalogModels())
+      setDownloads((d) => ({ ...d, [model.id]: 0 }))
+    },
+    []
+  )
+
+  const setSkillEnabled = useCallback(
+    async (name: string, enabled: boolean) => {
+      setCapabilities(await mindClient.setSkillEnabled(name, enabled))
+    },
+    []
+  )
+
+  const addMcpServer = useCallback(async (name: string, url: string) => {
+    setCapabilities(await mindClient.addMcpServer(name, url))
+  }, [])
+
+  const removeMcpServer = useCallback(async (id: string) => {
+    setCapabilities(await mindClient.removeMcpServer(id))
+  }, [])
+
   const chat = useCallback(async (prompt: string) => {
     const res = await mindClient.chat(prompt)
     return { text: res.text, thinking: res.thinking }
@@ -189,7 +234,10 @@ export function useMind(): UseMindResult {
   )
 
   return {
+    addHuggingFaceModel,
+    addMcpServer,
     cancelDownload,
+    capabilities,
     catalog,
     chat,
     deleteModel,
@@ -201,7 +249,9 @@ export function useMind(): UseMindResult {
     pendingConfirm,
     ready: status?.on === true && !loading,
     refresh,
+    removeMcpServer,
     respondConfirm,
+    setSkillEnabled,
     startProvider,
     status,
     stopProvider,

--- a/src/routes/kaleido-mind/agent.tsx
+++ b/src/routes/kaleido-mind/agent.tsx
@@ -1,0 +1,523 @@
+// Agent — the autonomy control surface. Lists scheduled tasks (the agent's
+// "task brain"), arms/disarms the scheduler, shows run history + cost, and
+// gates autonomous spending behind a dry-run / risk-limit switch.
+
+import {
+  Activity,
+  AlertTriangle,
+  Check,
+  Clock,
+  Gauge,
+  Loader2,
+  Pause,
+  PieChart,
+  Play,
+  Power,
+  ShieldAlert,
+  ShieldCheck,
+} from 'lucide-react'
+import React, { useCallback, useEffect, useState } from 'react'
+
+import {
+  mindClient,
+  type AgentState,
+  type AgentTask,
+  type MindEvent,
+  type PortfolioTargets,
+} from '../../api/mind'
+
+import { MindCard } from './shared'
+
+function fmtInterval(sec: number): string {
+  if (sec <= 0) return 'manual only'
+  if (sec < 3600) return `every ${Math.max(1, Math.round(sec / 60))} min`
+  if (sec < 86400) return `every ${Math.round(sec / 3600)}h`
+  const d = Math.round(sec / 86400)
+  return d === 1 ? 'daily' : `every ${d}d`
+}
+
+function fmtAgo(ts: number | null): string {
+  if (!ts) return 'never run'
+  const s = Math.floor((Date.now() - ts) / 1000)
+  if (s < 60) return `${s}s ago`
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+export const Component: React.FC = () => {
+  const [tasks, setTasks] = useState<AgentTask[]>([])
+  const [agent, setAgent] = useState<AgentState | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const [t, s] = await Promise.all([
+        mindClient.listTasks(),
+        mindClient.getAgentState(),
+      ])
+      setTasks(t)
+      setAgent(s)
+    } catch {
+      /* sidecar may still be booting */
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const off = mindClient.on((e: MindEvent) => {
+      if (e.type === 'tasks_changed') setTasks(e.tasks)
+      else if (e.type === 'agent_state') setAgent(e.state)
+      else if (e.type === 'task_run_finished') void refresh()
+    })
+    return off
+  }, [refresh])
+
+  const dryRun = agent?.risk.dryRun ?? true
+  const running = agent?.schedulerRunning ?? false
+
+  const toggleScheduler = async () => {
+    setAgent(await mindClient.setScheduler(!running))
+  }
+  const toggleDryRun = async () => {
+    setAgent(await mindClient.setRiskLimits({ dryRun: !dryRun }))
+  }
+  const saveTargets = async (t: PortfolioTargets) => {
+    setAgent(await mindClient.setPortfolioTargets(t))
+  }
+  const saveLimits = async (g: {
+    maxThinkingTokens: number
+    maxOutputTokens: number
+  }) => {
+    setAgent(await mindClient.setGenerationLimits(g))
+  }
+  const toggleTask = async (t: AgentTask) => {
+    await mindClient.updateTask(t.id, { enabled: !t.enabled })
+    // tasks_changed event refreshes the list
+  }
+  const runNow = async (t: AgentTask) => {
+    setBusy(t.id)
+    try {
+      await mindClient.runTask(t.id)
+    } catch {
+      /* surfaced via run history */
+    } finally {
+      setBusy(null)
+      void refresh()
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Scheduler + dry-run controls */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <MindCard>
+          <div className="flex items-start gap-3">
+            <div
+              className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg ${
+                running
+                  ? 'bg-green-600/20 text-green-300'
+                  : 'bg-gray-700/40 text-gray-400'
+              }`}
+            >
+              <Power className="h-5 w-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h3 className="text-sm font-semibold text-white">Scheduler</h3>
+              <p className="mt-0.5 text-xs text-gray-400">
+                {running
+                  ? 'Enabled tasks fire on their interval while a model is loaded.'
+                  : 'Tasks are paused. Turn on to let enabled tasks run automatically.'}
+              </p>
+            </div>
+            <button
+              className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${
+                running
+                  ? 'bg-gray-700/60 text-gray-200 hover:bg-gray-700'
+                  : 'bg-green-600 text-white hover:bg-green-500'
+              }`}
+              onClick={() => void toggleScheduler()}
+              type="button"
+            >
+              {running ? (
+                <>
+                  <Pause className="h-3.5 w-3.5" /> Pause
+                </>
+              ) : (
+                <>
+                  <Play className="h-3.5 w-3.5" /> Start
+                </>
+              )}
+            </button>
+          </div>
+        </MindCard>
+
+        <MindCard>
+          <div className="flex items-start gap-3">
+            <div
+              className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg ${
+                dryRun
+                  ? 'bg-blue-600/20 text-blue-300'
+                  : 'bg-amber-600/20 text-amber-300'
+              }`}
+            >
+              {dryRun ? (
+                <ShieldCheck className="h-5 w-5" />
+              ) : (
+                <ShieldAlert className="h-5 w-5" />
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <h3 className="text-sm font-semibold text-white">
+                {dryRun ? 'Dry run — safe' : 'Live spending'}
+              </h3>
+              <p className="mt-0.5 text-xs text-gray-400">
+                {dryRun
+                  ? 'Autonomous runs describe what they would do; no funds move.'
+                  : 'Autonomous runs may spend within the risk limits below.'}
+              </p>
+            </div>
+            <button
+              className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${
+                dryRun
+                  ? 'bg-amber-600 text-white hover:bg-amber-500'
+                  : 'bg-blue-600 text-white hover:bg-blue-500'
+              }`}
+              onClick={() => void toggleDryRun()}
+              type="button"
+            >
+              {dryRun ? 'Go live' : 'Dry run'}
+            </button>
+          </div>
+        </MindCard>
+      </div>
+
+      {/* Risk limits */}
+      {agent && (
+        <MindCard>
+          <div className="mb-3 flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-400" />
+            <h3 className="text-sm font-semibold text-white">Risk limits</h3>
+            <span className="ml-auto text-xs text-gray-500">
+              enforced on every autonomous spend
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Limit label="Max spend" value={`$${agent.risk.maxSpendUsd}`} />
+            <Limit
+              label="Auto-approve ≤"
+              value={`$${agent.risk.autoApproveUnderUsd}`}
+            />
+            <Limit
+              label="BTC reserve"
+              value={`${agent.risk.minBtcReserveSat.toLocaleString()} sat`}
+            />
+            <Limit
+              label="Stop-loss"
+              value={`${agent.risk.stopLossBtcSat.toLocaleString()} sat`}
+            />
+          </div>
+        </MindCard>
+      )}
+
+      {/* Portfolio targets */}
+      {agent && <TargetsCard onSave={saveTargets} targets={agent.targets} />}
+
+      {/* Response limits — bound how long a turn can take (token caps) */}
+      {agent && (
+        <LimitsCard generation={agent.generation} onSave={saveLimits} />
+      )}
+
+      {/* Tasks */}
+      <MindCard>
+        <div className="mb-3 flex items-center gap-2">
+          <Clock className="h-4 w-4 text-violet-400" />
+          <h3 className="text-sm font-semibold text-white">Scheduled tasks</h3>
+          <span className="ml-auto text-xs text-gray-500">
+            {tasks.filter((t) => t.enabled).length} of {tasks.length} enabled
+          </span>
+        </div>
+        {tasks.length === 0 ? (
+          <p className="py-4 text-center text-sm text-gray-500">
+            No tasks yet.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {tasks.map((t) => (
+              <div
+                className="flex items-center gap-3 rounded-lg border border-gray-800 bg-gray-900/40 p-3"
+                key={t.id}
+              >
+                <button
+                  aria-label={t.enabled ? 'Disable task' : 'Enable task'}
+                  className={`relative h-5 w-9 flex-shrink-0 rounded-full transition-colors ${
+                    t.enabled ? 'bg-green-500' : 'bg-gray-600'
+                  }`}
+                  onClick={() => void toggleTask(t)}
+                  type="button"
+                >
+                  <span
+                    className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
+                      t.enabled ? 'translate-x-4' : 'translate-x-0.5'
+                    }`}
+                  />
+                </button>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <p className="truncate text-sm font-medium text-white">
+                      {t.name}
+                    </p>
+                    <span className="rounded bg-violet-600/20 px-1.5 py-0.5 text-[0.65rem] font-medium text-violet-300">
+                      {t.skill}
+                    </span>
+                  </div>
+                  <p className="truncate text-xs text-gray-400">
+                    {fmtInterval(t.scheduleSec)} · last {fmtAgo(t.lastRunAt)}
+                  </p>
+                </div>
+                <button
+                  className="flex items-center gap-1.5 rounded-lg border border-gray-700 px-2.5 py-1.5 text-xs text-gray-200 hover:bg-gray-800 disabled:opacity-50"
+                  disabled={busy === t.id}
+                  onClick={() => void runNow(t)}
+                  type="button"
+                >
+                  {busy === t.id ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Play className="h-3.5 w-3.5" />
+                  )}
+                  Run now
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </MindCard>
+
+      {/* Run history */}
+      <MindCard>
+        <div className="mb-3 flex items-center gap-2">
+          <Activity className="h-4 w-4 text-violet-400" />
+          <h3 className="text-sm font-semibold text-white">Recent runs</h3>
+          {agent && (
+            <span className="ml-auto text-xs text-gray-500">
+              {agent.cumulative.usd > 0
+                ? `$${agent.cumulative.usd.toFixed(4)} spent`
+                : 'local model — no API cost'}
+            </span>
+          )}
+        </div>
+        {!agent || agent.recent.length === 0 ? (
+          <p className="py-4 text-center text-sm text-gray-500">
+            No runs yet. Enable a task or hit “Run now”.
+          </p>
+        ) : (
+          <div className="space-y-1.5">
+            {agent.recent.slice(0, 12).map((r, i) => (
+              <div
+                className="flex items-center gap-3 rounded px-2 py-1.5 text-xs hover:bg-gray-800/60"
+                key={`${r.taskId}-${r.startedAt}-${i}`}
+              >
+                <span
+                  className={`h-1.5 w-1.5 flex-shrink-0 rounded-full ${
+                    r.ok ? 'bg-green-400' : 'bg-red-400'
+                  }`}
+                />
+                <span className="w-32 flex-shrink-0 truncate font-medium text-gray-200">
+                  {r.taskName}
+                </span>
+                <span className="truncate text-gray-400">
+                  {r.ok ? r.text || 'ok' : (r.error ?? 'failed')}
+                </span>
+                <span className="ml-auto flex-shrink-0 text-gray-500">
+                  {r.toolCalls} tools · {Math.round(r.durationMs / 100) / 10}s ·{' '}
+                  {fmtAgo(r.startedAt)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </MindCard>
+    </div>
+  )
+}
+
+const Limit: React.FC<{ label: string; value: string }> = ({
+  label,
+  value,
+}) => (
+  <div className="rounded-lg border border-gray-800 bg-gray-900/40 px-3 py-2">
+    <p className="text-[0.65rem] uppercase tracking-wide text-gray-500">
+      {label}
+    </p>
+    <p className="mt-0.5 font-mono text-sm text-gray-100">{value}</p>
+  </div>
+)
+
+const TargetInput: React.FC<{
+  label: string
+  value: number
+  onChange: (v: number) => void
+}> = ({ label, onChange, value }) => (
+  <div className="rounded-lg border border-gray-800 bg-gray-900/40 px-3 py-2">
+    <p className="text-[0.65rem] uppercase tracking-wide text-gray-500">
+      {label}
+    </p>
+    <input
+      className="mt-0.5 w-full bg-transparent font-mono text-sm text-gray-100 focus:outline-none"
+      inputMode="numeric"
+      onChange={(e) => onChange(Number(e.target.value))}
+      type="number"
+      value={value}
+    />
+  </div>
+)
+
+/** Editable BTC/USDT/XAUT target weights + drift trigger; saves to the agent. */
+const TargetsCard: React.FC<{
+  targets: PortfolioTargets
+  onSave: (t: PortfolioTargets) => Promise<void>
+}> = ({ onSave, targets }) => {
+  const [draft, setDraft] = useState<PortfolioTargets>(targets)
+  const [saving, setSaving] = useState(false)
+  // Re-sync if the upstream targets change (another client / a save round-trip).
+  useEffect(() => setDraft(targets), [targets])
+
+  const sum = draft.btcPct + draft.usdtPct + draft.xautPct
+  const dirty =
+    draft.btcPct !== targets.btcPct ||
+    draft.usdtPct !== targets.usdtPct ||
+    draft.xautPct !== targets.xautPct ||
+    draft.driftThresholdPct !== targets.driftThresholdPct
+  const set = (k: keyof PortfolioTargets, v: number) =>
+    setDraft((d) => ({ ...d, [k]: Number.isFinite(v) ? v : 0 }))
+  const save = async () => {
+    setSaving(true)
+    try {
+      await onSave(draft)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <MindCard>
+      <div className="mb-3 flex items-center gap-2">
+        <PieChart className="h-4 w-4 text-violet-400" />
+        <h3 className="text-sm font-semibold text-white">Portfolio targets</h3>
+        <span
+          className={`ml-auto text-xs ${sum === 100 ? 'text-gray-500' : 'text-amber-400'}`}
+        >
+          {sum === 100 ? 'sums to 100%' : `sum = ${sum}% (must be 100%)`}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <TargetInput
+          label="BTC %"
+          onChange={(v) => set('btcPct', v)}
+          value={draft.btcPct}
+        />
+        <TargetInput
+          label="USDT %"
+          onChange={(v) => set('usdtPct', v)}
+          value={draft.usdtPct}
+        />
+        <TargetInput
+          label="XAUT %"
+          onChange={(v) => set('xautPct', v)}
+          value={draft.xautPct}
+        />
+        <TargetInput
+          label="Drift trigger %"
+          onChange={(v) => set('driftThresholdPct', v)}
+          value={draft.driftThresholdPct}
+        />
+      </div>
+      <div className="mt-3 flex justify-end">
+        <button
+          className="inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-violet-500 disabled:opacity-40"
+          disabled={!dirty || sum !== 100 || saving}
+          onClick={() => void save()}
+          type="button"
+        >
+          {saving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Check className="h-3.5 w-3.5" />
+          )}
+          Save targets
+        </button>
+      </div>
+    </MindCard>
+  )
+}
+
+/** Editable thinking + total-output token caps (0 = uncapped); saves live. */
+const LimitsCard: React.FC<{
+  generation: { maxThinkingTokens: number; maxOutputTokens: number }
+  onSave: (g: {
+    maxThinkingTokens: number
+    maxOutputTokens: number
+  }) => Promise<void>
+}> = ({ generation, onSave }) => {
+  const [draft, setDraft] = useState(generation)
+  const [saving, setSaving] = useState(false)
+  useEffect(() => setDraft(generation), [generation])
+
+  const clamp = (v: number) =>
+    Number.isFinite(v) ? Math.max(0, Math.round(v)) : 0
+  const dirty =
+    draft.maxThinkingTokens !== generation.maxThinkingTokens ||
+    draft.maxOutputTokens !== generation.maxOutputTokens
+  const save = async () => {
+    setSaving(true)
+    try {
+      await onSave(draft)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <MindCard>
+      <div className="mb-3 flex items-center gap-2">
+        <Gauge className="h-4 w-4 text-violet-400" />
+        <h3 className="text-sm font-semibold text-white">Response limits</h3>
+        <span className="ml-auto text-xs text-gray-500">
+          0 = uncapped · ~30 tokens/sec
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <TargetInput
+          label="Max thinking tokens"
+          onChange={(v) =>
+            setDraft((d) => ({ ...d, maxThinkingTokens: clamp(v) }))
+          }
+          value={draft.maxThinkingTokens}
+        />
+        <TargetInput
+          label="Max response tokens"
+          onChange={(v) =>
+            setDraft((d) => ({ ...d, maxOutputTokens: clamp(v) }))
+          }
+          value={draft.maxOutputTokens}
+        />
+      </div>
+      <div className="mt-3 flex justify-end">
+        <button
+          className="inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-violet-500 disabled:opacity-40"
+          disabled={!dirty || saving}
+          onClick={() => void save()}
+          type="button"
+        >
+          {saving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Check className="h-3.5 w-3.5" />
+          )}
+          Save limits
+        </button>
+      </div>
+    </MindCard>
+  )
+}

--- a/src/routes/kaleido-mind/brain.tsx
+++ b/src/routes/kaleido-mind/brain.tsx
@@ -46,7 +46,17 @@ export const Component: React.FC = () => {
       {
         icon: <Cpu className="h-4 w-4" />,
         label: 'Active model',
-        value: providerOn ? (status?.activeModelName ?? 'Running') : '—',
+        value: providerOn
+          ? `${status?.activeModelName ?? 'Running'} · ${
+              status?.inferenceDevice === 'gpu'
+                ? 'Metal/GPU'
+                : status?.inferenceDevice === 'cpu'
+                  ? 'CPU'
+                  : status?.inferenceDevice === 'mock'
+                    ? 'Mock'
+                    : 'detecting'
+            }`
+          : '—',
       },
       {
         icon: <Gauge className="h-4 w-4" />,

--- a/src/routes/kaleido-mind/brain.tsx
+++ b/src/routes/kaleido-mind/brain.tsx
@@ -1,35 +1,89 @@
-// Brain — KaleidoMind overview + settings. Summarizes the provider state and
-// lets you start/stop the brain; Settings exposes the public key and logs.
+// Brain — KaleidoMind control panel. A compact, screen-fitting hub: start/stop
+// the brain (with a clear "start a model" prompt when it's off), and open Models,
+// Skills, Pairing and Activity in modals so the page never overflows.
 
 import {
+  Activity,
   Check,
+  ChevronRight,
   Copy,
   Cpu,
   Gauge,
+  KeyRound,
+  Loader2,
   Play,
-  Settings as SettingsIcon,
+  Power,
+  QrCode,
+  Sparkles,
   Square,
   Users,
+  Zap,
 } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React, { useState } from 'react'
 
-import { KALEIDO_MIND_MODELS_PATH } from '../../app/router/paths'
+import { Modal } from '../../components/ui/Modal'
 
-import { MindCard, useMindContext } from './shared'
+import { ModelsManager } from './models'
+import { PairingPanel } from './pairing'
+import { useMindContext } from './shared'
+import { SkillsManager } from './skills'
+
+type ActiveModal = null | 'models' | 'skills' | 'pairing' | 'activity'
+
+/** A tappable tile in the quick-actions grid. */
+const ActionTile: React.FC<{
+  icon: React.ReactNode
+  label: string
+  hint: string
+  onClick: () => void
+}> = ({ icon, label, hint, onClick }) => (
+  <button
+    className="group flex items-center gap-3 rounded-xl border border-border-default bg-surface-overlay/40 p-3.5 text-left transition-all hover:-translate-y-0.5 hover:border-primary/40 hover:bg-surface-overlay"
+    onClick={onClick}
+    type="button"
+  >
+    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary">
+      {icon}
+    </span>
+    <span className="min-w-0 flex-1">
+      <span className="block text-sm font-semibold text-content-primary">
+        {label}
+      </span>
+      <span className="block truncate text-xs text-content-tertiary">
+        {hint}
+      </span>
+    </span>
+    <ChevronRight className="h-4 w-4 shrink-0 text-content-tertiary transition-transform group-hover:translate-x-0.5" />
+  </button>
+)
 
 export const Component: React.FC = () => {
   const mind = useMindContext()
-  const navigate = useNavigate()
   const { status } = mind
   const providerOn = status?.on === true
+  const loading = mind.loading
 
   const installed = mind.installed
   const [selectedModel, setSelectedModel] = useState<string>('')
-  const activeModelId = status?.activeModelId ?? ''
   const startModelId = selectedModel || installed[0]?.id || ''
-
+  const [modal, setModal] = useState<ActiveModal>(null)
   const [copied, setCopied] = useState(false)
+
+  const device = status?.inferenceDevice
+  const onGpu = device === 'gpu'
+  const deviceLabel = onGpu
+    ? 'Metal/GPU'
+    : device === 'cpu'
+      ? 'CPU'
+      : device === 'mock'
+        ? 'Mock'
+        : 'detecting'
+  const tps = status?.tokensPerSecond
+  const peers = status?.peers.length ?? 0
+  const enabledSkills =
+    mind.capabilities?.skills.filter((s) => s.enabled).length ?? 0
+  const toolCount = mind.capabilities?.tools.length ?? 0
+
   const copyKey = async () => {
     if (!status?.publicKey) return
     try {
@@ -41,156 +95,259 @@ export const Component: React.FC = () => {
     }
   }
 
-  const stats = useMemo(
-    () => [
-      {
-        icon: <Cpu className="h-4 w-4" />,
-        label: 'Active model',
-        value: providerOn
-          ? `${status?.activeModelName ?? 'Running'} · ${
-              status?.inferenceDevice === 'gpu'
-                ? 'Metal/GPU'
-                : status?.inferenceDevice === 'cpu'
-                  ? 'CPU'
-                  : status?.inferenceDevice === 'mock'
-                    ? 'Mock'
-                    : 'detecting'
-            }`
-          : '—',
-      },
-      {
-        icon: <Gauge className="h-4 w-4" />,
-        label: 'Throughput',
-        value:
-          providerOn && typeof status?.tokensPerSecond === 'number'
-            ? `${status.tokensPerSecond.toFixed(0)} tok/s`
-            : '—',
-      },
-      {
-        icon: <Users className="h-4 w-4" />,
-        label: 'Paired phones',
-        value: providerOn ? String(status?.peers.length ?? 0) : '—',
-      },
-    ],
-    [providerOn, status]
-  )
-
   return (
-    <div className="flex flex-col gap-6">
-      {/* Overview */}
-      <MindCard>
-        <div className="mb-4 flex items-center gap-2">
-          <Cpu className="h-5 w-5 text-gray-300" />
-          <h2 className="font-semibold text-white">Overview</h2>
-        </div>
-
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-          {stats.map((s) => (
-            <div
-              className="rounded-lg border border-gray-800 bg-gray-900/60 p-3"
-              key={s.label}
+    <div className="flex flex-col gap-4">
+      {/* ── Hero: status + start/stop ──────────────────────────────────── */}
+      <section className="overflow-hidden rounded-2xl border border-border-default bg-surface-base/50">
+        <div className="flex flex-col gap-4 p-5 sm:flex-row sm:items-center">
+          <div className="flex items-center gap-3.5">
+            <span
+              className={`relative flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl ${
+                providerOn ? 'bg-primary/15' : 'bg-surface-overlay'
+              }`}
             >
-              <div className="flex items-center gap-2 text-xs text-gray-500">
-                {s.icon}
-                {s.label}
-              </div>
-              <div className="mt-1 truncate text-sm font-semibold text-white">
-                {s.value}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          {providerOn ? (
-            <button
-              className="flex items-center gap-1.5 rounded-md bg-red-600/80 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-600"
-              onClick={() => mind.stopProvider()}
-            >
-              <Square className="h-4 w-4" /> Stop brain
-            </button>
-          ) : installed.length > 0 ? (
-            <>
-              <select
-                className="rounded-md border border-gray-700 bg-gray-900 px-2.5 py-1.5 text-sm text-white focus:border-violet-500 focus:outline-none"
-                onChange={(e) => setSelectedModel(e.target.value)}
-                value={startModelId}
-              >
-                {installed.map((m) => (
-                  <option key={m.id} value={m.id}>
-                    {m.id}
-                  </option>
-                ))}
-              </select>
-              <button
-                className="flex items-center gap-1.5 rounded-md bg-violet-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-violet-500 disabled:opacity-40"
-                disabled={!startModelId}
-                onClick={() => startModelId && mind.startProvider(startModelId)}
-              >
-                <Play className="h-4 w-4" /> Start brain
-              </button>
-            </>
-          ) : (
-            <button
-              className="flex items-center gap-1.5 rounded-md border border-gray-700 px-3 py-1.5 text-sm text-gray-200 hover:bg-gray-800"
-              onClick={() => navigate(KALEIDO_MIND_MODELS_PATH)}
-            >
-              <Cpu className="h-4 w-4" /> Get a model to start
-            </button>
-          )}
-          {activeModelId && (
-            <span className="text-xs text-gray-500">
-              active: <span className="font-mono">{activeModelId}</span>
+              <Power
+                className={`h-6 w-6 ${providerOn ? 'text-primary' : 'text-content-tertiary'}`}
+              />
+              {providerOn && (
+                <span className="absolute -right-0.5 -top-0.5 h-3 w-3 animate-pulse rounded-full border-2 border-surface-base bg-status-success" />
+              )}
             </span>
-          )}
-        </div>
-      </MindCard>
-
-      {/* Settings */}
-      <MindCard>
-        <div className="mb-4 flex items-center gap-2">
-          <SettingsIcon className="h-5 w-5 text-gray-300" />
-          <h2 className="font-semibold text-white">Settings</h2>
-        </div>
-
-        <div className="space-y-4">
-          <div>
-            <div className="mb-1 text-xs text-gray-500">
-              Provider public key
-            </div>
-            {status?.publicKey ? (
-              <button
-                className="flex items-center gap-2 rounded-md border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
-                onClick={copyKey}
-              >
-                {copied ? (
-                  <Check className="h-3.5 w-3.5" />
-                ) : (
-                  <Copy className="h-3.5 w-3.5" />
-                )}
-                <span className="font-mono">
-                  {status.publicKey.slice(0, 12)}…{status.publicKey.slice(-8)}
-                </span>
-              </button>
-            ) : (
-              <p className="text-sm text-gray-600">
-                Available once the brain is running.
+            <div className="min-w-0">
+              <h2 className="text-base font-semibold text-content-primary">
+                {providerOn
+                  ? 'Brain is online'
+                  : loading
+                    ? 'Starting the brain…'
+                    : 'Brain is offline'}
+              </h2>
+              <p className="truncate text-sm text-content-tertiary">
+                {providerOn
+                  ? (status?.activeModelName ?? 'Running')
+                  : loading
+                    ? (loading.message ?? 'Loading model…')
+                    : 'Start a model to chat, run skills, and pair a phone.'}
               </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+            {providerOn ? (
+              <button
+                className="inline-flex items-center gap-1.5 rounded-lg border border-status-danger/40 bg-status-danger/10 px-3 py-2 text-sm font-medium text-status-danger transition-colors hover:bg-status-danger/20"
+                onClick={() => mind.stopProvider()}
+                type="button"
+              >
+                <Square className="h-4 w-4" /> Stop brain
+              </button>
+            ) : installed.length > 0 ? (
+              <>
+                <select
+                  className="rounded-lg border border-border-default bg-surface-overlay px-2.5 py-2 text-sm text-content-primary focus:border-primary focus:outline-none disabled:opacity-50"
+                  disabled={!!loading}
+                  onChange={(e) => setSelectedModel(e.target.value)}
+                  value={startModelId}
+                >
+                  {installed.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.displayName || m.id}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3.5 py-2 text-sm font-semibold text-surface-base transition-all hover:bg-primary-emphasis active:scale-95 disabled:opacity-50"
+                  disabled={!startModelId || !!loading}
+                  onClick={() =>
+                    startModelId && mind.startProvider(startModelId)
+                  }
+                  type="button"
+                >
+                  {loading ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Play className="h-4 w-4" />
+                  )}
+                  {loading ? 'Starting…' : 'Start brain'}
+                </button>
+              </>
+            ) : (
+              <button
+                className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3.5 py-2 text-sm font-semibold text-surface-base transition-all hover:bg-primary-emphasis active:scale-95"
+                onClick={() => setModal('models')}
+                type="button"
+              >
+                <Cpu className="h-4 w-4" /> Get a model
+              </button>
             )}
           </div>
+        </div>
 
-          <div>
-            <div className="mb-1 text-xs text-gray-500">Recent activity</div>
-            <div className="max-h-40 overflow-y-auto rounded-md border border-gray-800 bg-black/30 p-2 font-mono text-[11px] leading-relaxed text-gray-400">
-              {mind.logs.length === 0 ? (
-                <span className="text-gray-600">No log output yet.</span>
-              ) : (
-                mind.logs.slice(-50).map((line, i) => <div key={i}>{line}</div>)
-              )}
+        {/* Live stats strip — only meaningful when running. */}
+        {providerOn && (
+          <div className="grid grid-cols-3 divide-x divide-divider/10 border-t border-divider/10">
+            <div className="px-4 py-3">
+              <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
+                {onGpu ? (
+                  <Zap className="h-3.5 w-3.5" />
+                ) : (
+                  <Cpu className="h-3.5 w-3.5" />
+                )}
+                Backend
+              </div>
+              <div
+                className={`mt-0.5 text-sm font-semibold ${
+                  onGpu
+                    ? 'text-status-success'
+                    : device === 'cpu'
+                      ? 'text-status-warning'
+                      : 'text-content-primary'
+                }`}
+              >
+                {deviceLabel}
+              </div>
+            </div>
+            <div className="px-4 py-3">
+              <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
+                <Gauge className="h-3.5 w-3.5" />
+                Throughput
+              </div>
+              <div className="mt-0.5 text-sm font-semibold text-content-primary">
+                {typeof tps === 'number' && tps > 0
+                  ? `${tps.toFixed(0)} tok/s`
+                  : '—'}
+              </div>
+            </div>
+            <div className="px-4 py-3">
+              <div className="flex items-center gap-1.5 text-xs text-content-tertiary">
+                <Users className="h-3.5 w-3.5" />
+                Paired
+              </div>
+              <div className="mt-0.5 text-sm font-semibold text-content-primary">
+                {peers}
+              </div>
             </div>
           </div>
+        )}
+      </section>
+
+      {/* ── Quick actions (open in modals / navigate) ──────────────────── */}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <ActionTile
+          hint={`${installed.length} installed`}
+          icon={<Cpu className="h-5 w-5" />}
+          label="Models"
+          onClick={() => setModal('models')}
+        />
+        <ActionTile
+          hint={
+            mind.capabilities
+              ? `${enabledSkills} skills · ${toolCount} tools`
+              : 'Skills & MCP tools'
+          }
+          icon={<Sparkles className="h-5 w-5" />}
+          label="Skills & tools"
+          onClick={() => setModal('skills')}
+        />
+        <ActionTile
+          hint={
+            providerOn ? `${peers} phone(s) paired` : 'Delegate from a phone'
+          }
+          icon={<QrCode className="h-5 w-5" />}
+          label="Phone pairing"
+          onClick={() => setModal('pairing')}
+        />
+        <ActionTile
+          hint={`${mind.logs.length} log line(s)`}
+          icon={<Activity className="h-5 w-5" />}
+          label="Recent activity"
+          onClick={() => setModal('activity')}
+        />
+      </div>
+
+      {/* ── Provider key (compact) ─────────────────────────────────────── */}
+      <section className="flex items-center gap-3 rounded-xl border border-border-default bg-surface-base/50 p-4">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-surface-overlay text-content-secondary">
+          <KeyRound className="h-4 w-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-content-primary">
+            Provider key
+          </p>
+          <p className="truncate text-xs text-content-tertiary">
+            {status?.publicKey
+              ? 'This brain’s public identity for paired phones.'
+              : 'Available once the brain is running.'}
+          </p>
         </div>
-      </MindCard>
+        {status?.publicKey && (
+          <button
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border-default px-2.5 py-1.5 font-mono text-xs text-content-secondary transition-colors hover:bg-surface-overlay"
+            onClick={copyKey}
+            type="button"
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-status-success" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+            {status.publicKey.slice(0, 8)}…{status.publicKey.slice(-6)}
+          </button>
+        )}
+      </section>
+
+      {/* ── Modals ─────────────────────────────────────────────────────── */}
+      <Modal
+        isOpen={modal === 'models'}
+        onClose={() => setModal(null)}
+        size="lg"
+        title="Models"
+      >
+        <div className="p-4">
+          <ModelsManager />
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={modal === 'skills'}
+        onClose={() => setModal(null)}
+        size="lg"
+        title="Skills & tools"
+      >
+        <div className="p-4">
+          <SkillsManager />
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={modal === 'pairing'}
+        onClose={() => setModal(null)}
+        size="sm"
+        title="Phone pairing"
+      >
+        <div className="p-4">
+          <PairingPanel />
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={modal === 'activity'}
+        onClose={() => setModal(null)}
+        size="md"
+        title="Recent activity"
+      >
+        <div className="p-4">
+          <div className="max-h-[60vh] overflow-y-auto rounded-lg border border-border-default bg-surface-base/60 p-3 font-mono text-[11px] leading-relaxed text-content-tertiary">
+            {mind.logs.length === 0 ? (
+              <span className="text-content-tertiary">
+                No log output yet. Start the brain to see model load, inference
+                backend and tool activity here.
+              </span>
+            ) : (
+              mind.logs.slice(-200).map((line, i) => <div key={i}>{line}</div>)
+            )}
+          </div>
+        </div>
+      </Modal>
     </div>
   )
 }

--- a/src/routes/kaleido-mind/cards.tsx
+++ b/src/routes/kaleido-mind/cards.tsx
@@ -1,0 +1,791 @@
+// Typed result cards for KaleidoMind chat.
+//
+// The sidecar streams `chat_tool_call` / `chat_tool_result` events for every
+// tool the agent runs. Instead of letting the model re-narrate JSON as prose,
+// we render a standardized card per known tool (balance, channels, invoice, …)
+// keyed by tool name — a Claude-like structured experience. Unknown tools fall
+// back to a generic, defensive renderer. Every card reads whatever fields exist
+// and degrades gracefully, since tool output shapes can drift.
+
+import { QRCodeSVG } from 'qrcode.react'
+import {
+  AlertTriangle,
+  ArrowDownLeft,
+  ArrowLeftRight,
+  ArrowUpRight,
+  Check,
+  Coins,
+  Copy,
+  Loader2,
+  MapPin,
+  Network,
+  QrCode,
+  Send,
+  Server,
+  ShoppingBag,
+  Store,
+  Wallet,
+} from 'lucide-react'
+import React, { useState } from 'react'
+
+import { useBitcoinPrice } from '../../hooks/useBitcoinPrice'
+
+import type { ChatToolEvent } from './shared'
+
+// ── Formatting helpers ───────────────────────────────────────────────────
+
+/** Format a sats value (number or numeric string) → "12,345 sats", else null. */
+export function fmtSats(n: unknown): string | null {
+  const v = typeof n === 'number' ? n : Number(n)
+  return Number.isFinite(v) ? `${v.toLocaleString('en-US')} sats` : null
+}
+
+/** Format a millisat value → "12,345 sats" (msat/1000), else null. */
+export function fmtMsat(n: unknown): string | null {
+  const v = typeof n === 'number' ? n : Number(n)
+  return Number.isFinite(v) ? fmtSats(Math.round(v / 1000)) : null
+}
+
+function num(n: unknown): number | null {
+  // Treat null/undefined/'' as "no value" — `Number(null)` is 0, which would
+  // otherwise render real null amounts (e.g. an amountless invoice) as "0 sats".
+  if (n == null || n === '') return null
+  const v = typeof n === 'number' ? n : Number(n)
+  return Number.isFinite(v) ? v : null
+}
+
+/** Tool results arrive as a JSON string (MCP text content). Coerce to a value. */
+export function coerce(result: unknown): unknown {
+  if (typeof result === 'string') {
+    const s = result.trim()
+    if (s.startsWith('{') || s.startsWith('[')) {
+      try {
+        return JSON.parse(s)
+      } catch {
+        return result
+      }
+    }
+    return result
+  }
+  return result
+}
+
+function asObj(result: unknown): Record<string, unknown> | null {
+  const v = coerce(result)
+  return v && typeof v === 'object' && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null
+}
+
+function truncMiddle(s: string, head = 10, tail = 8): string {
+  return s.length > head + tail + 1
+    ? `${s.slice(0, head)}…${s.slice(-tail)}`
+    : s
+}
+
+/** Humanize a tool name for the live "running" pill, e.g. "Checking balance". */
+export function humanizeToolName(name: string): string {
+  const map: Record<string, string> = {
+    find_merchant_locations: 'Finding merchants nearby',
+    kaleidoswap_get_quote: 'Getting a quote',
+    kaleidoswap_lsp_create_asset_channel: 'Buying a channel',
+    kaleidoswap_lsp_estimate_fees: 'Estimating channel fees',
+    kaleidoswap_lsp_get_info: 'Checking the LSP',
+    kaleidoswap_lsp_quote_asset_channel: 'Quoting a channel',
+    rln_close_channel: 'Closing a channel',
+    rln_create_ln_invoice: 'Creating an invoice',
+    rln_create_rgb_invoice: 'Creating an RGB invoice',
+    rln_get_address: 'Getting an address',
+    rln_get_asset_balance: 'Checking asset balance',
+    rln_get_balances: 'Checking your balance',
+    rln_get_node_info: 'Reading node info',
+    rln_list_assets: 'Listing your assets',
+    rln_list_channels: 'Reading your channels',
+    rln_list_payments: 'Loading payments',
+    rln_list_swaps: 'Loading swaps',
+    rln_open_channel: 'Opening a channel',
+    rln_pay_invoice: 'Paying the invoice',
+    rln_send_asset: 'Sending the asset',
+    rln_send_btc: 'Sending BTC',
+  }
+  const base = name.replace(/^(wdk|rln)_/, 'rln_')
+  return map[name] ?? map[base] ?? name.replace(/_/g, ' ')
+}
+
+// ── Small UI atoms ───────────────────────────────────────────────────────
+
+const CopyButton: React.FC<{ value: string; label?: string }> = ({
+  value,
+  label,
+}) => {
+  const [done, setDone] = useState(false)
+  return (
+    <button
+      className="inline-flex items-center gap-1 rounded-md border border-border-default px-1.5 py-0.5 text-[0.68rem] text-content-tertiary transition-colors hover:bg-surface-overlay hover:text-content-secondary"
+      onClick={() => {
+        void navigator.clipboard.writeText(value).then(() => {
+          setDone(true)
+          setTimeout(() => setDone(false), 1200)
+        })
+      }}
+      title="Copy"
+      type="button"
+    >
+      {done ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      {label}
+    </button>
+  )
+}
+
+const Shell: React.FC<{
+  icon: React.ReactNode
+  title: string
+  accent?: string
+  children: React.ReactNode
+}> = ({ icon, title, accent = 'text-primary', children }) => (
+  <div className="my-2 overflow-hidden rounded-xl border border-border-default bg-surface-base/60">
+    <div className="flex items-center gap-2 border-b border-divider/10 bg-surface-overlay/40 px-3 py-2">
+      <span className={accent}>{icon}</span>
+      <span className="text-xs font-semibold text-content-primary">
+        {title}
+      </span>
+    </div>
+    <div className="px-3 py-2.5">{children}</div>
+  </div>
+)
+
+const Row: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <div className="flex items-baseline justify-between gap-3 py-0.5 text-sm">
+    <span className="text-content-tertiary">{label}</span>
+    <span className="text-right font-medium text-content-primary">
+      {children}
+    </span>
+  </div>
+)
+
+/** Horizontal outbound/inbound capacity bar (msat in). */
+const CapacityBar: React.FC<{ outMsat: number; inMsat: number }> = ({
+  outMsat,
+  inMsat,
+}) => {
+  const total = Math.max(outMsat + inMsat, 1)
+  const outPct = Math.round((outMsat / total) * 100)
+  return (
+    <div className="mt-1 flex h-1.5 overflow-hidden rounded-full bg-surface-overlay">
+      <div className="bg-primary" style={{ width: `${outPct}%` }} />
+      <div
+        className="bg-status-info/60"
+        style={{ width: `${100 - outPct}%` }}
+      />
+    </div>
+  )
+}
+
+type CardProps = {
+  data: unknown
+  args?: Record<string, unknown>
+}
+
+// ── Cards ────────────────────────────────────────────────────────────────
+
+const BalanceCard: React.FC<CardProps> = ({ data }) => {
+  const { formatFiat } = useBitcoinPrice()
+  const o = asObj(data)
+  if (!o) return <GenericCard data={data} />
+  const oc = asObj(o.btc_onchain) ?? {}
+  const onchain =
+    (num(oc.vanilla_spendable_sats) ?? 0) +
+    (num(oc.colored_spendable_sats) ?? 0)
+  const ln = num(o.lightning_balance_sat)
+  // Asset balance shape (rln_get_asset_balance): { asset_id, spendable, ... }
+  const assetId = typeof o.asset_id === 'string' ? o.asset_id : null
+  const assetSpendable = num(o.spendable)
+  const fiat = (sats: number) => formatFiat(sats)
+  return (
+    <Shell icon={<Wallet className="h-4 w-4" />} title="Balance">
+      {ln != null && (
+        <Row label="Lightning">
+          {fmtSats(ln)}
+          {fiat(ln) && (
+            <span className="ml-1.5 text-xs text-content-tertiary">
+              {fiat(ln)}
+            </span>
+          )}
+        </Row>
+      )}
+      {!assetId && (
+        <Row label="On-chain (spendable)">
+          {fmtSats(onchain)}
+          {fiat(onchain) && (
+            <span className="ml-1.5 text-xs text-content-tertiary">
+              {fiat(onchain)}
+            </span>
+          )}
+        </Row>
+      )}
+      {assetId && assetSpendable != null && (
+        <Row label={`Asset ${truncMiddle(assetId)}`}>
+          {assetSpendable.toLocaleString('en-US')}
+        </Row>
+      )}
+      {ln != null && !assetId && (
+        <div className="mt-1.5 flex items-center justify-between border-t border-divider/10 pt-1.5 text-sm">
+          <span className="text-content-secondary">Total spendable</span>
+          <span className="font-semibold text-content-primary">
+            {fmtSats(ln + onchain)}
+          </span>
+        </div>
+      )}
+    </Shell>
+  )
+}
+
+const ChannelsCard: React.FC<CardProps> = ({ data }) => {
+  const o = asObj(data)
+  const channels = Array.isArray(o?.channels)
+    ? (o!.channels as Record<string, unknown>[])
+    : Array.isArray(coerce(data))
+      ? (coerce(data) as Record<string, unknown>[])
+      : []
+  if (!channels.length) {
+    return (
+      <Shell icon={<Network className="h-4 w-4" />} title="Channels">
+        <p className="text-sm text-content-tertiary">No channels yet.</p>
+      </Shell>
+    )
+  }
+  const totalOut = num(o?.total_outbound_msat)
+  const totalIn = num(o?.total_inbound_msat)
+  return (
+    <Shell
+      icon={<Network className="h-4 w-4" />}
+      title={`Channels · ${channels.length}`}
+    >
+      {(totalOut != null || totalIn != null) && (
+        <div className="mb-2 flex gap-4 text-xs text-content-tertiary">
+          {totalOut != null && (
+            <span>
+              Send <b className="text-content-secondary">{fmtMsat(totalOut)}</b>
+            </span>
+          )}
+          {totalIn != null && (
+            <span>
+              Receive{' '}
+              <b className="text-content-secondary">{fmtMsat(totalIn)}</b>
+            </span>
+          )}
+        </div>
+      )}
+      <div className="space-y-2.5">
+        {channels.slice(0, 6).map((c, i) => {
+          const out = num(c.outbound_balance_msat) ?? 0
+          const inb = num(c.inbound_balance_msat) ?? 0
+          const peer =
+            (typeof c.peer_alias === 'string' && c.peer_alias) ||
+            (typeof c.peer_pubkey === 'string' && c.peer_pubkey) ||
+            (typeof c.counterparty === 'string' && c.counterparty) ||
+            (typeof c.channel_id === 'string' && c.channel_id) ||
+            `Channel ${i + 1}`
+          const usable = c.is_usable === true || c.ready === true
+          const assetId = typeof c.asset_id === 'string' ? c.asset_id : null
+          return (
+            <div key={(c.channel_id as string) ?? i}>
+              <div className="flex items-center justify-between text-xs">
+                <span className="truncate font-mono text-content-secondary">
+                  {truncMiddle(String(peer))}
+                </span>
+                <span
+                  className={`ml-2 shrink-0 rounded-full px-1.5 py-0.5 text-[0.6rem] font-medium ${
+                    usable
+                      ? 'bg-status-success/15 text-status-success'
+                      : 'bg-surface-overlay text-content-tertiary'
+                  }`}
+                >
+                  {usable ? 'usable' : 'pending'}
+                </span>
+              </div>
+              <CapacityBar inMsat={inb} outMsat={out} />
+              <div className="mt-0.5 flex justify-between text-[0.65rem] text-content-tertiary">
+                <span>{fmtMsat(out)} out</span>
+                {assetId && <span>RGB {truncMiddle(assetId, 6, 4)}</span>}
+                <span>{fmtMsat(inb)} in</span>
+              </div>
+            </div>
+          )
+        })}
+        {channels.length > 6 && (
+          <p className="text-[0.65rem] text-content-tertiary">
+            +{channels.length - 6} more
+          </p>
+        )}
+      </div>
+    </Shell>
+  )
+}
+
+const AssetsCard: React.FC<CardProps> = ({ data }) => {
+  const v = coerce(data)
+  // Accept an array, or an object whose values are asset arrays (nia/cfa/…).
+  let assets: Record<string, unknown>[] = []
+  if (Array.isArray(v)) assets = v as Record<string, unknown>[]
+  else if (v && typeof v === 'object') {
+    for (const val of Object.values(v as Record<string, unknown>)) {
+      if (Array.isArray(val)) assets.push(...(val as Record<string, unknown>[]))
+    }
+  }
+  if (!assets.length) return <GenericCard data={data} />
+  return (
+    <Shell
+      icon={<Coins className="h-4 w-4" />}
+      title={`Assets · ${assets.length}`}
+    >
+      <div className="space-y-1">
+        {assets.slice(0, 8).map((a, i) => {
+          const ticker =
+            (typeof a.ticker === 'string' && a.ticker) ||
+            (typeof a.name === 'string' && a.name) ||
+            'Asset'
+          // Balance is a nested object in raw base units; show the spendable
+          // amount (on-chain, else the LN-outbound holding) scaled by precision.
+          const balObj = asObj(a.balance)
+          const precision = num(a.precision) ?? 0
+          const rawBal = balObj
+            ? num(balObj.spendable) ||
+              num(balObj.offchain_outbound) ||
+              num(balObj.settled) ||
+              0
+            : (num(a.balance) ?? num(a.spendable) ?? 0)
+          const bal = precision > 0 ? rawBal / 10 ** precision : rawBal
+          return (
+            <div
+              className="flex items-baseline justify-between gap-2 text-sm"
+              key={(a.asset_id as string) ?? i}
+            >
+              <span className="truncate font-medium text-content-primary">
+                {ticker}
+                {typeof a.name === 'string' && a.name !== ticker && (
+                  <span className="ml-1.5 text-xs font-normal text-content-tertiary">
+                    {a.name}
+                  </span>
+                )}
+              </span>
+              <span className="shrink-0 font-mono text-content-secondary">
+                {bal.toLocaleString('en-US', {
+                  maximumFractionDigits: Math.min(precision, 8),
+                })}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </Shell>
+  )
+}
+
+const InvoiceCard: React.FC<CardProps> = ({ data, args }) => {
+  const o = asObj(data) ?? {}
+  const payable =
+    (typeof o.invoice === 'string' && o.invoice) ||
+    (typeof o.address === 'string' && o.address) ||
+    (typeof o.bolt11 === 'string' && o.bolt11) ||
+    (typeof o.recipient_id === 'string' && o.recipient_id) ||
+    (typeof coerce(data) === 'string' ? (coerce(data) as string) : '')
+  const amount = num(args?.amount_sat) ?? num(args?.amount) ?? num(o.amount_sat)
+  if (!payable) return <GenericCard data={data} />
+  return (
+    <Shell icon={<QrCode className="h-4 w-4" />} title="Payment request">
+      <div className="flex flex-col items-center gap-2">
+        <div className="rounded-lg bg-white p-2">
+          <QRCodeSVG level="M" size={148} value={payable} />
+        </div>
+        {amount != null && (
+          <span className="text-sm font-semibold text-content-primary">
+            {fmtSats(amount)}
+          </span>
+        )}
+        <div className="flex w-full items-center gap-2 rounded-md border border-border-default bg-surface-overlay/40 px-2 py-1">
+          <span className="flex-1 truncate font-mono text-[0.68rem] text-content-tertiary">
+            {payable}
+          </span>
+          <CopyButton value={payable} />
+        </div>
+      </div>
+    </Shell>
+  )
+}
+
+const PaymentSentCard: React.FC<CardProps> = ({ data }) => {
+  const o = asObj(data)
+  if (!o) return <GenericCard data={data} />
+  const amount =
+    num(o.amount_sat) ?? num(o.amount_msat) ?? num(o.amount_display)
+  const isMsat = o.amount_msat != null && o.amount_sat == null
+  const ref =
+    (typeof o.txid === 'string' && o.txid) ||
+    (typeof o.payment_hash === 'string' && o.payment_hash) ||
+    (typeof o.payment_preimage === 'string' && o.payment_preimage) ||
+    null
+  const status =
+    (typeof o.status === 'string' && o.status) ||
+    (o.sent ? 'sent' : 'submitted')
+  return (
+    <Shell
+      accent="text-status-success"
+      icon={<Send className="h-4 w-4" />}
+      title="Payment sent"
+    >
+      {amount != null && (
+        <Row label="Amount">
+          {isMsat
+            ? fmtMsat(amount)
+            : (fmtSats(amount) ?? amount.toLocaleString())}
+        </Row>
+      )}
+      {num(o.fee_sat) != null && <Row label="Fee">{fmtSats(o.fee_sat)}</Row>}
+      <Row label="Status">
+        <span className="capitalize text-status-success">{status}</span>
+      </Row>
+      {ref && (
+        <div className="mt-1 flex items-center justify-between gap-2">
+          <span className="truncate font-mono text-[0.68rem] text-content-tertiary">
+            {truncMiddle(ref, 12, 10)}
+          </span>
+          <CopyButton value={ref} />
+        </div>
+      )}
+    </Shell>
+  )
+}
+
+const PaymentsCard: React.FC<CardProps> = ({ data }) => {
+  const v = coerce(data)
+  const list = Array.isArray(v)
+    ? (v as Record<string, unknown>[])
+    : Array.isArray(asObj(data)?.payments)
+      ? (asObj(data)!.payments as Record<string, unknown>[])
+      : Array.isArray(asObj(data)?.swaps)
+        ? (asObj(data)!.swaps as Record<string, unknown>[])
+        : []
+  if (!list.length) {
+    return (
+      <Shell icon={<ArrowLeftRight className="h-4 w-4" />} title="Payments">
+        <p className="text-sm text-content-tertiary">No payments found.</p>
+      </Shell>
+    )
+  }
+  return (
+    <Shell
+      icon={<ArrowLeftRight className="h-4 w-4" />}
+      title={`Payments · ${list.length}`}
+    >
+      <div className="space-y-1.5">
+        {list.slice(0, 8).map((p, i) => {
+          const inbound =
+            p.inbound === true ||
+            p.direction === 'inbound' ||
+            p.direction === 'received'
+          const amt = num(p.amount_sat) ?? fmtMsat(p.amt_msat) ?? num(p.amount)
+          const status =
+            (typeof p.status === 'string' && p.status) ||
+            (typeof p.state === 'string' && p.state) ||
+            ''
+          return (
+            <div
+              className="flex items-center gap-2 text-sm"
+              key={(p.payment_hash as string) ?? i}
+            >
+              {inbound ? (
+                <ArrowDownLeft className="h-3.5 w-3.5 shrink-0 text-status-success" />
+              ) : (
+                <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-status-info" />
+              )}
+              <span className="flex-1 font-medium text-content-primary">
+                {typeof amt === 'number' ? fmtSats(amt) : (amt ?? '—')}
+              </span>
+              {status && (
+                <span
+                  className={`text-[0.65rem] capitalize ${
+                    /fail|error|expired/i.test(status)
+                      ? 'text-status-danger'
+                      : /succe|complete|paid/i.test(status)
+                        ? 'text-status-success'
+                        : 'text-content-tertiary'
+                  }`}
+                >
+                  {status}
+                </span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </Shell>
+  )
+}
+
+const ChannelBuyCard: React.FC<CardProps> = ({ data, args }) => {
+  const o = asObj(data) ?? {}
+  const asset = String(args?.asset ?? o.asset ?? '')
+  const amount = args?.asset_amount ?? o.asset_amount
+  const total = fmtSats(
+    o.total_sat ?? o.order_total_sat ?? o.onchain_amount_sat ?? args?.total_sat
+  )
+  const fee = fmtSats(
+    o.channel_fee_sat ?? o.fee_total_sat ?? o.total_fee ?? o.fee_sat
+  )
+  const price = fmtSats(o.btc_amount_sat)
+  const state =
+    (typeof o.order_state === 'string' && o.order_state) ||
+    (typeof o.status === 'string' && o.status) ||
+    null
+  return (
+    <Shell icon={<Network className="h-4 w-4" />} title="Channel quote">
+      {asset && (
+        <Row label="Asset">
+          {amount ? `${amount} ` : ''}
+          {asset}
+        </Row>
+      )}
+      {price && <Row label="Asset price">{price}</Row>}
+      {fee && <Row label="Channel fee">{fee}</Row>}
+      {state && <Row label="Status">{state}</Row>}
+      {total && (
+        <div className="mt-1.5 flex items-center justify-between border-t border-divider/10 pt-1.5 text-sm">
+          <span className="text-content-secondary">You pay</span>
+          <span className="font-semibold text-content-primary">{total}</span>
+        </div>
+      )}
+      {!asset && !total && <GenericCard data={data} />}
+    </Shell>
+  )
+}
+
+const NodeInfoCard: React.FC<CardProps> = ({ data }) => {
+  const o = asObj(data)
+  if (!o) return <GenericCard data={data} />
+  const pubkey =
+    (typeof o.pubkey === 'string' && o.pubkey) ||
+    (typeof o.node_id === 'string' && o.node_id) ||
+    null
+  return (
+    <Shell icon={<Server className="h-4 w-4" />} title="Node">
+      {pubkey && (
+        <div className="mb-1 flex items-center justify-between gap-2">
+          <span className="truncate font-mono text-[0.68rem] text-content-tertiary">
+            {truncMiddle(pubkey, 14, 10)}
+          </span>
+          <CopyButton value={pubkey} />
+        </div>
+      )}
+      {num(o.num_channels) != null && (
+        <Row label="Channels">
+          {String(o.num_channels)}
+          {num(o.num_usable_channels) != null &&
+            ` (${o.num_usable_channels} usable)`}
+        </Row>
+      )}
+      {num(o.num_peers) != null && (
+        <Row label="Peers">{String(o.num_peers)}</Row>
+      )}
+      {num(o.local_balance_sat) != null && (
+        <Row label="Lightning">{fmtSats(o.local_balance_sat)}</Row>
+      )}
+      {typeof o.network === 'string' && <Row label="Network">{o.network}</Row>}
+      {num(o.block_height) != null && (
+        <Row label="Block height">
+          {(num(o.block_height) as number).toLocaleString('en-US')}
+        </Row>
+      )}
+    </Shell>
+  )
+}
+
+/** Format a distance in metres → "420 m" or "1.3 km". */
+function fmtDistance(m: unknown): string | null {
+  const v = num(m)
+  if (v == null) return null
+  return v < 1000 ? `${Math.round(v)} m` : `${(v / 1000).toFixed(1)} km`
+}
+
+const MerchantCard: React.FC<CardProps> = ({ data }) => {
+  const o = asObj(data)
+  const merchants = Array.isArray(o?.merchants)
+    ? (o!.merchants as Record<string, unknown>[])
+    : Array.isArray(coerce(data))
+      ? (coerce(data) as Record<string, unknown>[])
+      : []
+  if (!merchants.length) {
+    const note = o && typeof o.note === 'string' ? o.note : null
+    return (
+      <Shell icon={<Store className="h-4 w-4" />} title="Merchants">
+        <p className="text-sm text-content-tertiary">
+          {note ?? 'No Bitcoin-accepting merchants found nearby.'}
+        </p>
+      </Shell>
+    )
+  }
+  return (
+    <Shell
+      icon={<Store className="h-4 w-4" />}
+      title={`Merchants · ${merchants.length}`}
+    >
+      <div className="space-y-2">
+        {merchants.slice(0, 8).map((m, i) => {
+          const name =
+            (typeof m.name === 'string' && m.name) || `Merchant ${i + 1}`
+          const category = typeof m.category === 'string' ? m.category : null
+          const address = typeof m.address === 'string' ? m.address : null
+          const dist = fmtDistance(m.distance_m)
+          return (
+            <div
+              className="flex items-start gap-2 border-b border-divider/10 pb-2 last:border-0 last:pb-0"
+              key={(m.id as string | number) ?? i}
+            >
+              <MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="truncate text-sm font-medium text-content-primary">
+                    {name}
+                  </span>
+                  {dist && (
+                    <span className="shrink-0 text-xs text-content-tertiary">
+                      {dist}
+                    </span>
+                  )}
+                </div>
+                {(category || address) && (
+                  <p className="truncate text-xs text-content-tertiary">
+                    {[category, address].filter(Boolean).join(' · ')}
+                  </p>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </Shell>
+  )
+}
+
+/** Generic fallback: arrays → compact list, objects → key/value rows. */
+const GenericCard: React.FC<CardProps & { title?: string }> = ({
+  data,
+  title = 'Result',
+}) => {
+  const v = coerce(data)
+  if (Array.isArray(v)) {
+    return (
+      <Shell icon={<ShoppingBag className="h-4 w-4" />} title={title}>
+        <div className="space-y-1">
+          {v.slice(0, 8).map((item, i) => (
+            <div className="truncate text-sm text-content-secondary" key={i}>
+              {typeof item === 'object'
+                ? Object.values(item as Record<string, unknown>)
+                    .filter(
+                      (x) => typeof x === 'string' || typeof x === 'number'
+                    )
+                    .slice(0, 3)
+                    .join(' · ')
+                : String(item)}
+            </div>
+          ))}
+        </div>
+      </Shell>
+    )
+  }
+  const o = asObj(data)
+  if (o) {
+    const entries = Object.entries(o).filter(
+      ([, val]) => val != null && typeof val !== 'object'
+    )
+    return (
+      <Shell icon={<ShoppingBag className="h-4 w-4" />} title={title}>
+        {entries.slice(0, 8).map(([k, val]) => (
+          <Row key={k} label={k.replace(/_/g, ' ')}>
+            <span className="font-mono text-xs">
+              {truncMiddle(String(val), 16, 8)}
+            </span>
+          </Row>
+        ))}
+      </Shell>
+    )
+  }
+  return (
+    <Shell icon={<ShoppingBag className="h-4 w-4" />} title={title}>
+      <p className="whitespace-pre-wrap break-words text-sm text-content-secondary">
+        {String(v).slice(0, 600)}
+      </p>
+    </Shell>
+  )
+}
+
+const ErrorCard: React.FC<CardProps & { name: string }> = ({ data, name }) => {
+  const o = asObj(data)
+  const msg =
+    (o && typeof o.error === 'string' && o.error) ||
+    (o && o.declined ? `Declined${o.reason ? `: ${o.reason}` : ''}` : '') ||
+    'Tool failed'
+  return (
+    <Shell
+      accent="text-status-danger"
+      icon={<AlertTriangle className="h-4 w-4" />}
+      title={humanizeToolName(name)}
+    >
+      <p className="text-sm text-status-danger">{msg}</p>
+    </Shell>
+  )
+}
+
+// ── Registry + dispatch ──────────────────────────────────────────────────
+
+type CardComponent = React.FC<CardProps>
+
+/** Map a tool name (rln_/wdk_/kaleidoswap_) to its card. */
+function cardFor(name: string): CardComponent {
+  const n = name.replace(/^wdk_/, 'rln_')
+  const registry: Record<string, CardComponent> = {
+    find_merchant_locations: MerchantCard,
+    kaleidoswap_lsp_create_asset_channel: ChannelBuyCard,
+    kaleidoswap_lsp_estimate_fees: ChannelBuyCard,
+    kaleidoswap_lsp_quote_asset_channel: ChannelBuyCard,
+    rln_create_ln_invoice: InvoiceCard,
+    rln_create_rgb_invoice: InvoiceCard,
+    rln_get_address: InvoiceCard,
+    rln_get_asset_balance: BalanceCard,
+    rln_get_balances: BalanceCard,
+    rln_get_node_info: NodeInfoCard,
+    rln_list_assets: AssetsCard,
+    rln_list_channels: ChannelsCard,
+    rln_list_payments: PaymentsCard,
+    rln_list_swaps: PaymentsCard,
+    rln_pay_invoice: PaymentSentCard,
+    rln_send_asset: PaymentSentCard,
+    rln_send_btc: PaymentSentCard,
+  }
+  return registry[n] ?? ((p) => <GenericCard {...p} />)
+}
+
+/**
+ * Render a single tool event: a live "running" pill, the typed result card, or
+ * an error card. This is what chat.tsx drops inline into the assistant bubble.
+ */
+export const ToolEventView: React.FC<{ event: ChatToolEvent }> = ({
+  event,
+}) => {
+  if (event.status === 'running') {
+    return (
+      <div className="my-1.5 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-xs text-primary">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        {humanizeToolName(event.name)}…
+      </div>
+    )
+  }
+  if (event.status === 'error') {
+    return <ErrorCard data={event.result} name={event.name} />
+  }
+  const Card = cardFor(event.name)
+  return <Card args={event.arguments} data={event.result} />
+}

--- a/src/routes/kaleido-mind/chat.tsx
+++ b/src/routes/kaleido-mind/chat.tsx
@@ -1,6 +1,13 @@
 // Chat — talk to the local brain. Routes through skills + connected MCP tools.
 
-import { Brain, Loader2, Send, ShieldAlert } from 'lucide-react'
+import {
+  Brain,
+  ChevronRight,
+  Loader2,
+  Send,
+  ShieldAlert,
+  Sparkles,
+} from 'lucide-react'
 import React, { useRef, useState } from 'react'
 import ReactMarkdown, { type Components } from 'react-markdown'
 
@@ -56,6 +63,35 @@ const MD_COMPONENTS: Components = {
 const MarkdownText: React.FC<{ text: string }> = ({ text }) => (
   <ReactMarkdown components={MD_COMPONENTS}>{text}</ReactMarkdown>
 )
+
+/**
+ * Collapsible view of the model's `<think>` reasoning for an assistant turn.
+ * Hidden by default — click to expand and see how the brain reasoned (which
+ * tools it considered, etc.).
+ */
+const ThinkingDisclosure: React.FC<{ text: string }> = ({ text }) => {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="mb-2">
+      <button
+        className="inline-flex items-center gap-1 rounded-md py-0.5 text-[0.7rem] font-medium text-content-tertiary transition-colors hover:text-content-secondary"
+        onClick={() => setOpen((o) => !o)}
+        type="button"
+      >
+        <ChevronRight
+          className={`h-3 w-3 transition-transform ${open ? 'rotate-90' : ''}`}
+        />
+        <Sparkles className="h-3 w-3" />
+        {open ? 'Hide thinking' : 'Show thinking'}
+      </button>
+      {open && (
+        <div className="mt-1.5 whitespace-pre-wrap break-words rounded-lg border border-divider/10 bg-surface-base/60 px-3 py-2 font-mono text-[0.72rem] leading-relaxed text-content-tertiary">
+          {text}
+        </div>
+      )}
+    </div>
+  )
+}
 
 /** Compact human form of a pending tool call's arguments. */
 function describeArgs(args: Record<string, unknown>): string {
@@ -137,7 +173,10 @@ export const Component: React.FC = () => {
     scrollToEnd()
     try {
       const reply = await mind.chat(prompt)
-      setMessages((m) => [...m, { role: 'assistant', text: reply }])
+      setMessages((m) => [
+        ...m,
+        { role: 'assistant', text: reply.text, thinking: reply.thinking },
+      ])
     } catch (e) {
       setMessages((m) => [
         ...m,
@@ -227,6 +266,7 @@ export const Component: React.FC = () => {
                   <Brain className="h-4 w-4 text-primary" />
                 </div>
                 <div className="max-w-[80%] break-words rounded-2xl rounded-tl-md border border-divider/10 bg-surface-overlay px-3.5 py-2.5 text-sm leading-relaxed text-content-primary">
+                  {m.thinking && <ThinkingDisclosure text={m.thinking} />}
                   <MarkdownText text={m.text} />
                 </div>
               </div>

--- a/src/routes/kaleido-mind/chat.tsx
+++ b/src/routes/kaleido-mind/chat.tsx
@@ -3,15 +3,32 @@
 import {
   Brain,
   ChevronRight,
+  Clock,
+  Coins,
+  Cpu,
+  Gauge,
+  History,
   Loader2,
+  Plus,
   Send,
   ShieldAlert,
   Sparkles,
+  Trash2,
+  Zap,
 } from 'lucide-react'
 import React, { useRef, useState } from 'react'
 import ReactMarkdown, { type Components } from 'react-markdown'
+import remarkBreaks from 'remark-breaks'
+import remarkGfm from 'remark-gfm'
 
-import { useMindContext, useMindChat } from './shared'
+import { ToolEventView, fmtSats } from './cards'
+import {
+  useMindContext,
+  useMindChat,
+  type ChatMsgStats,
+  type ChatToolEvent,
+} from './shared'
+import { FollowupActions, WelcomeActions } from './welcome-actions'
 
 /**
  * Render the agent's Markdown (bold, lists, IDs) instead of raw `**text**`.
@@ -55,37 +72,133 @@ const MD_COMPONENTS: Components = {
   strong: ({ node: _node, ...p }) => (
     <strong className="font-semibold text-content-primary" {...p} />
   ),
+  table: ({ node: _node, ...p }) => (
+    <div className="mb-2 overflow-x-auto last:mb-0">
+      <table className="w-full border-collapse text-xs" {...p} />
+    </div>
+  ),
+  td: ({ node: _node, ...p }) => (
+    <td
+      className="border border-divider/15 px-2 py-1 text-content-secondary"
+      {...p}
+    />
+  ),
+  th: ({ node: _node, ...p }) => (
+    <th
+      className="border border-divider/20 px-2 py-1 text-left font-semibold text-content-primary"
+      {...p}
+    />
+  ),
   ul: ({ node: _node, ...p }) => (
     <ul className="mb-2 list-disc space-y-1 pl-4 last:mb-0" {...p} />
   ),
 }
 
+// remark-gfm → proper lists/tables/strikethrough; remark-breaks → a single
+// newline becomes a <br>. Small local models emit line-separated text (not
+// blank-line-separated paragraphs), which plain CommonMark collapses into one
+// run-on blob — these keep the model's intended line/list structure.
 const MarkdownText: React.FC<{ text: string }> = ({ text }) => (
-  <ReactMarkdown components={MD_COMPONENTS}>{text}</ReactMarkdown>
+  <ReactMarkdown
+    components={MD_COMPONENTS}
+    remarkPlugins={[remarkGfm, remarkBreaks]}
+  >
+    {text}
+  </ReactMarkdown>
 )
 
 /**
- * Collapsible view of the model's `<think>` reasoning for an assistant turn.
- * Hidden by default — click to expand and see how the brain reasoned (which
- * tools it considered, etc.).
+ * Per-response stats footer — real QVAC numbers (tok/s, tokens used, the backend
+ * device) plus the wall-clock timing the user actually waited.
  */
-const ThinkingDisclosure: React.FC<{ text: string }> = ({ text }) => {
-  const [open, setOpen] = useState(false)
+const StatsFooter: React.FC<{ stats: ChatMsgStats }> = ({ stats }) => {
+  const { tokensPerSecond, tokens, promptTokens, latencyMs, device } = stats
+  const hasAny =
+    (typeof tokensPerSecond === 'number' && tokensPerSecond > 0) ||
+    typeof tokens === 'number' ||
+    typeof latencyMs === 'number' ||
+    !!device
+  if (!hasAny) return null
   return (
-    <div className="mb-2">
+    <div className="mt-2 flex flex-wrap items-center gap-x-2.5 gap-y-0.5 border-t border-divider/10 pt-1.5 text-[0.65rem] text-content-tertiary">
+      {typeof tokensPerSecond === 'number' && tokensPerSecond > 0 && (
+        <span className="inline-flex items-center gap-1">
+          <Gauge className="h-3 w-3" />
+          {tokensPerSecond.toFixed(1)} tok/s
+        </span>
+      )}
+      {typeof tokens === 'number' && (
+        <span
+          className="inline-flex items-center gap-1"
+          title={
+            typeof promptTokens === 'number'
+              ? `${promptTokens.toLocaleString('en-US')} prompt + ${Math.max(
+                  0,
+                  tokens - promptTokens
+                ).toLocaleString('en-US')} completion`
+              : undefined
+          }
+        >
+          <Coins className="h-3 w-3" />
+          {tokens.toLocaleString('en-US')} tokens
+        </span>
+      )}
+      {typeof latencyMs === 'number' && (
+        <span className="inline-flex items-center gap-1">
+          <Clock className="h-3 w-3" />
+          {(latencyMs / 1000).toFixed(latencyMs < 10_000 ? 1 : 0)}s
+        </span>
+      )}
+      {device && (
+        <span className="inline-flex items-center gap-1">
+          {device === 'gpu' ? (
+            <Zap className="h-3 w-3" />
+          ) : (
+            <Cpu className="h-3 w-3" />
+          )}
+          {device === 'gpu' ? 'GPU' : 'CPU'}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Collapsible view of the model's `<think>` reasoning for an assistant turn.
+ * Streams open WHILE the model is thinking (so you watch it reason live), then
+ * auto-collapses the moment the visible answer starts — a Claude-like
+ * thinking→answer transition. The user can still expand/collapse manually.
+ */
+const ThinkingDisclosure: React.FC<{
+  text: string
+  live?: boolean
+  hasContent?: boolean
+}> = ({ text, live = false, hasContent = false }) => {
+  // Actively reasoning = streaming this turn with no visible answer yet.
+  const reasoning = live && !hasContent
+  // Auto: open while there's no visible answer yet (you watch it think), then
+  // collapse once the answer appears. `pinnedOpen` lets a manual toggle win.
+  const [pinnedOpen, setPinnedOpen] = useState<boolean | null>(null)
+  const open = pinnedOpen ?? !hasContent
+  return (
+    <div className="mb-2 overflow-hidden rounded-lg border border-primary/20 bg-primary/5">
       <button
-        className="inline-flex items-center gap-1 rounded-md py-0.5 text-[0.7rem] font-medium text-content-tertiary transition-colors hover:text-content-secondary"
-        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+        onClick={() => setPinnedOpen(!open)}
         type="button"
       >
         <ChevronRight
           className={`h-3 w-3 transition-transform ${open ? 'rotate-90' : ''}`}
         />
-        <Sparkles className="h-3 w-3" />
-        {open ? 'Hide thinking' : 'Show thinking'}
+        <Sparkles className={`h-3 w-3 ${reasoning ? 'animate-pulse' : ''}`} />
+        <span>{reasoning ? 'Thinking…' : 'Thought process'}</span>
+        <span className="ml-auto text-[0.65rem] font-normal text-content-tertiary">
+          {open ? 'Hide' : 'Show'}
+        </span>
       </button>
       {open && (
-        <div className="mt-1.5 whitespace-pre-wrap break-words rounded-lg border border-divider/10 bg-surface-base/60 px-3 py-2 font-mono text-[0.72rem] leading-relaxed text-content-tertiary">
+        <div className="max-h-56 overflow-y-auto whitespace-pre-wrap break-words border-t border-primary/15 bg-surface-base/60 px-3 py-2.5 font-mono text-[0.72rem] leading-relaxed text-content-tertiary">
           {text}
         </div>
       )}
@@ -99,12 +212,6 @@ function describeArgs(args: Record<string, unknown>): string {
     .filter(([, v]) => v !== undefined && v !== null && v !== '')
     .map(([k, v]) => `${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
   return parts.join('\n')
-}
-
-/** Format a sats value (number or numeric string) → "12,345 sats", else null. */
-function fmtSats(n: unknown): string | null {
-  const v = typeof n === 'number' ? n : Number(n)
-  return Number.isFinite(v) ? `${v.toLocaleString('en-US')} sats` : null
 }
 
 interface ConfirmSummary {
@@ -141,21 +248,27 @@ function summarizeConfirm(
   return null
 }
 
-/** Starter prompts shown on the empty chat — one tap to try the agent. */
-const SUGGESTIONS = [
-  'What can you do?',
-  "What's my balance?",
-  'Do I have channels?',
-  'Buy 100 USDT',
-]
-
 export const Component: React.FC = () => {
   const mind = useMindContext()
   const providerOn = mind.status?.on === true
+  // Real inference backend + throughput (from the SDK's per-turn stats) — shown
+  // in the header so "is the GPU actually being used?" is answered where you chat.
+  const device = mind.status?.inferenceDevice
+  const onGpu = device === 'gpu'
+  const deviceLabel =
+    device === 'gpu'
+      ? 'Metal/GPU'
+      : device === 'cpu'
+        ? 'CPU'
+        : device === 'mock'
+          ? 'Mock'
+          : 'detecting'
+  const tps = mind.status?.tokensPerSecond
 
   // Persisted across Mind sub-tabs (owned by the layout).
   const { messages, setMessages, input, setInput } = useMindChat()
   const [sending, setSending] = useState(false)
+  const [showHistory, setShowHistory] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
 
   const scrollToEnd = () =>
@@ -167,24 +280,139 @@ export const Component: React.FC = () => {
   const send = async (override?: string) => {
     const prompt = (override ?? input).trim()
     if (!prompt || sending || !providerOn) return
+    const assistantId = crypto.randomUUID()
+    const now = Date.now()
     setInput('')
-    setMessages((m) => [...m, { role: 'user', text: prompt }])
+    setMessages((m) => [
+      ...m,
+      { createdAt: now, id: crypto.randomUUID(), role: 'user', text: prompt },
+      {
+        createdAt: now,
+        id: assistantId,
+        role: 'assistant',
+        streaming: true,
+        text: '',
+        thinking: '',
+      },
+    ])
     setSending(true)
     scrollToEnd()
+    // Correlate tool calls↔results by (name, occurrence). The sidecar fires the
+    // call event fire-and-forget after an async lookup, so a fast result can
+    // race ahead of its call — counting per name makes the i-th call and i-th
+    // result resolve to the same event key regardless of arrival order.
+    const callSeq = new Map<string, number>()
+    const resultSeq = new Map<string, number>()
+    const upsertToolEvent = (
+      key: string,
+      patch: Partial<ChatToolEvent>,
+      fallback: ChatToolEvent
+    ) => {
+      setMessages((current) =>
+        current.map((message) => {
+          if (message.id !== assistantId) return message
+          const events = message.toolEvents ?? []
+          const index = events.findIndex((e) => e.id === key)
+          if (index >= 0) {
+            const next = events.slice()
+            next[index] = { ...next[index], ...patch }
+            return { ...message, toolEvents: next }
+          }
+          return { ...message, toolEvents: [...events, fallback] }
+        })
+      )
+      scrollToEnd()
+    }
     try {
-      const reply = await mind.chat(prompt)
-      setMessages((m) => [
-        ...m,
-        { role: 'assistant', text: reply.text, thinking: reply.thinking },
-      ])
-    } catch (e) {
-      setMessages((m) => [
-        ...m,
-        {
-          role: 'assistant',
-          text: `⚠️ ${e instanceof Error ? e.message : String(e)}`,
+      const reply = await mind.chat(prompt, {
+        onThinking: (delta) => {
+          setMessages((current) =>
+            current.map((message) =>
+              message.id === assistantId
+                ? {
+                    ...message,
+                    thinking: `${message.thinking ?? ''}${delta}`,
+                  }
+                : message
+            )
+          )
+          scrollToEnd()
         },
-      ])
+        onToken: (delta) => {
+          setMessages((current) =>
+            current.map((message) =>
+              message.id === assistantId
+                ? { ...message, text: `${message.text}${delta}` }
+                : message
+            )
+          )
+          scrollToEnd()
+        },
+        onToolCall: (call) => {
+          const n = (callSeq.get(call.name) ?? 0) + 1
+          callSeq.set(call.name, n)
+          const key = `${call.name}#${n}`
+          upsertToolEvent(
+            key,
+            { arguments: call.arguments },
+            {
+              arguments: call.arguments,
+              id: key,
+              name: call.name,
+              status: 'running',
+            }
+          )
+        },
+        onToolResult: (res) => {
+          const n = (resultSeq.get(res.name) ?? 0) + 1
+          resultSeq.set(res.name, n)
+          const key = `${res.name}#${n}`
+          const status: ChatToolEvent['status'] = res.ok ? 'done' : 'error'
+          upsertToolEvent(
+            key,
+            { result: res.result, status },
+            {
+              arguments: res.arguments,
+              id: key,
+              name: res.name,
+              result: res.result,
+              status,
+            }
+          )
+        },
+      })
+      setMessages((current) =>
+        current.map((message) =>
+          message.id === assistantId
+            ? {
+                ...message,
+                followups: reply.followups,
+                stats: {
+                  device: reply.device,
+                  latencyMs: reply.latencyMs,
+                  promptTokens: reply.promptTokens,
+                  tokens: reply.tokens,
+                  tokensPerSecond: reply.tokensPerSecond,
+                },
+                streaming: false,
+                text: reply.text,
+                thinking: reply.thinking ?? message.thinking,
+              }
+            : message
+        )
+      )
+    } catch (e) {
+      setMessages((current) =>
+        current.map((message) =>
+          message.id === assistantId
+            ? {
+                ...message,
+                streaming: false,
+                text: `⚠️ ${e instanceof Error ? e.message : String(e)}`,
+              }
+            : message
+        )
+      )
     } finally {
       setSending(false)
       scrollToEnd()
@@ -208,21 +436,128 @@ export const Component: React.FC = () => {
               : 'Start a model to chat'}
           </p>
         </div>
-        <span
-          className={`ml-auto inline-flex flex-shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-[0.7rem] font-medium ${
-            providerOn
-              ? 'bg-primary/15 text-primary'
-              : 'bg-surface-overlay text-content-tertiary'
-          }`}
-        >
+        <div className="ml-auto flex flex-shrink-0 items-center gap-2">
+          {providerOn && (
+            <span
+              className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[0.7rem] font-medium ${
+                onGpu
+                  ? 'bg-status-success/15 text-status-success'
+                  : device === 'cpu'
+                    ? 'bg-status-warning/15 text-status-warning'
+                    : 'bg-surface-overlay text-content-tertiary'
+              }`}
+              title={
+                onGpu
+                  ? 'Inference is running on the GPU (Metal)'
+                  : device === 'cpu'
+                    ? 'Running on CPU — GPU/Metal was unavailable. See Brain → Recent activity.'
+                    : 'Detecting inference backend…'
+              }
+            >
+              {onGpu ? (
+                <Zap className="h-3 w-3" />
+              ) : (
+                <Cpu className="h-3 w-3" />
+              )}
+              {deviceLabel}
+              {typeof tps === 'number' && tps > 0
+                ? ` · ${tps.toFixed(0)} tok/s`
+                : ''}
+            </span>
+          )}
           <span
-            className={`h-1.5 w-1.5 rounded-full ${
-              providerOn ? 'animate-pulse bg-primary' : 'bg-content-tertiary'
+            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[0.7rem] font-medium ${
+              providerOn
+                ? 'bg-primary/15 text-primary'
+                : 'bg-surface-overlay text-content-tertiary'
             }`}
-          />
-          {providerOn ? 'Online' : 'Offline'}
-        </span>
+          >
+            <span
+              className={`h-1.5 w-1.5 rounded-full ${
+                providerOn ? 'animate-pulse bg-primary' : 'bg-content-tertiary'
+              }`}
+            />
+            {providerOn ? 'Online' : 'Offline'}
+          </span>
+        </div>
+        <button
+          className="inline-flex items-center gap-1.5 rounded-md border border-border-default px-2.5 py-1.5 text-xs text-content-secondary hover:bg-surface-overlay disabled:opacity-40 disabled:hover:bg-transparent"
+          disabled={messages.length === 0 || sending}
+          onClick={() => {
+            setMessages([])
+            setInput('')
+            setShowHistory(false)
+          }}
+          title="Start a new chat"
+          type="button"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New chat
+        </button>
+        <button
+          className="inline-flex items-center gap-1.5 rounded-md border border-border-default px-2.5 py-1.5 text-xs text-content-secondary hover:bg-surface-overlay"
+          onClick={() => setShowHistory((value) => !value)}
+          type="button"
+        >
+          <History className="h-3.5 w-3.5" />
+          History
+        </button>
       </div>
+
+      {showHistory && (
+        <div className="border-b border-divider/15 bg-surface-overlay/40 px-5 py-3">
+          <div className="mb-2 flex items-center">
+            <p className="text-xs font-semibold text-content-primary">
+              Saved conversation · {messages.length} messages
+            </p>
+            <div className="ml-auto flex gap-2">
+              <button
+                className="inline-flex items-center gap-1 text-xs text-content-tertiary hover:text-content-primary"
+                onClick={() => {
+                  setMessages([])
+                  setShowHistory(false)
+                }}
+                type="button"
+              >
+                <Plus className="h-3.5 w-3.5" /> New chat
+              </button>
+              <button
+                className="inline-flex items-center gap-1 text-xs text-red-400 hover:text-red-300"
+                onClick={() => setMessages([])}
+                type="button"
+              >
+                <Trash2 className="h-3.5 w-3.5" /> Clear
+              </button>
+            </div>
+          </div>
+          <div className="max-h-40 space-y-1 overflow-y-auto">
+            {messages.length === 0 ? (
+              <p className="text-xs text-content-tertiary">
+                No saved messages yet.
+              </p>
+            ) : (
+              messages.map((message, index) => (
+                <div
+                  className="flex gap-2 rounded px-2 py-1 text-xs hover:bg-surface-overlay"
+                  key={message.id ?? index}
+                >
+                  <span className="w-14 shrink-0 font-medium text-content-tertiary">
+                    {message.role === 'user' ? 'You' : 'Mind'}
+                  </span>
+                  <span className="truncate text-content-secondary">
+                    {message.text || message.thinking || 'Thinking…'}
+                  </span>
+                  {message.createdAt && (
+                    <span className="ml-auto shrink-0 text-[0.65rem] text-content-tertiary">
+                      {new Date(message.createdAt).toLocaleString()}
+                    </span>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Messages */}
       <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4" ref={listRef}>
@@ -232,57 +567,65 @@ export const Component: React.FC = () => {
               <Brain className="h-7 w-7 text-primary" />
             </div>
             <p className="text-base font-semibold text-content-primary">
-              How can I help?
+              Your sovereign financial agent
             </p>
             <p className="mt-1.5 max-w-sm text-sm leading-relaxed text-content-tertiary">
-              Your local AI brain for Bitcoin, Lightning &amp; RGB — read
-              balances and channels, or run a swap, right from chat.
+              I run locally and help with your wallet, node and portfolio. Pick
+              a starting point, or just ask.
             </p>
-            <div className="mt-5 flex flex-wrap justify-center gap-2">
-              {SUGGESTIONS.map((s) => (
-                <button
-                  className="rounded-full border border-border-default bg-surface-overlay/50 px-3.5 py-1.5 text-xs font-medium text-content-secondary transition-all hover:-translate-y-0.5 hover:border-primary/40 hover:text-content-primary disabled:opacity-40 disabled:hover:translate-y-0"
-                  disabled={!providerOn || sending}
-                  key={s}
-                  onClick={() => void send(s)}
-                  type="button"
-                >
-                  {s}
-                </button>
-              ))}
-            </div>
+            <WelcomeActions
+              disabled={!providerOn || sending}
+              onPick={(p) => void send(p)}
+              providerOn={providerOn}
+            />
           </div>
         ) : (
           messages.map((m, i) =>
             m.role === 'user' ? (
-              <div className="flex justify-end" key={i}>
+              <div className="flex justify-end" key={m.id ?? i}>
                 <div className="max-w-[80%] whitespace-pre-wrap break-words rounded-2xl rounded-br-md bg-secondary px-3.5 py-2.5 text-sm text-white shadow-sm">
                   {m.text}
                 </div>
               </div>
             ) : (
-              <div className="flex items-start gap-2.5" key={i}>
+              <div className="flex items-start gap-2.5" key={m.id ?? i}>
                 <div className="mt-0.5 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-primary/15">
                   <Brain className="h-4 w-4 text-primary" />
                 </div>
-                <div className="max-w-[80%] break-words rounded-2xl rounded-tl-md border border-divider/10 bg-surface-overlay px-3.5 py-2.5 text-sm leading-relaxed text-content-primary">
-                  {m.thinking && <ThinkingDisclosure text={m.thinking} />}
-                  <MarkdownText text={m.text} />
+                <div className="max-w-[88%] break-words rounded-2xl rounded-tl-md border border-divider/10 bg-surface-overlay px-3.5 py-2.5 text-sm leading-relaxed text-content-primary">
+                  {m.thinking && (
+                    <ThinkingDisclosure
+                      hasContent={!!m.text}
+                      live={m.streaming}
+                      text={m.thinking}
+                    />
+                  )}
+                  {m.toolEvents?.map((ev) => (
+                    <ToolEventView event={ev} key={ev.id} />
+                  ))}
+                  {m.text ? (
+                    <MarkdownText text={m.text} />
+                  ) : m.streaming && !m.thinking && !m.toolEvents?.length ? (
+                    <span className="inline-flex items-center gap-2 text-content-tertiary">
+                      <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                      Thinking…
+                    </span>
+                  ) : null}
+                  {!m.streaming &&
+                    m.followups &&
+                    m.followups.length > 0 &&
+                    i === messages.length - 1 && (
+                      <FollowupActions
+                        actions={m.followups}
+                        disabled={!providerOn || sending}
+                        onPick={(p) => void send(p)}
+                      />
+                    )}
+                  {!m.streaming && m.stats && <StatsFooter stats={m.stats} />}
                 </div>
               </div>
             )
           )
-        )}
-        {sending && (
-          <div className="flex items-start gap-2.5">
-            <div className="mt-0.5 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-primary/15">
-              <Brain className="h-4 w-4 text-primary" />
-            </div>
-            <div className="inline-flex items-center gap-2 rounded-2xl rounded-tl-md border border-divider/10 bg-surface-overlay px-3.5 py-2.5 text-sm text-content-tertiary">
-              <Loader2 className="h-4 w-4 animate-spin text-primary" />{' '}
-              thinking…
-            </div>
-          </div>
         )}
       </div>
 
@@ -353,25 +696,50 @@ export const Component: React.FC = () => {
         </div>
       )}
       <div className="border-t border-divider/15 px-4 py-3">
-        <div className="flex items-center gap-2 rounded-xl border border-border-default bg-surface-overlay/40 py-1.5 pl-3 pr-1.5 transition-colors focus-within:border-primary/50">
+        {/* While the model is working, make it unmistakable that input is paused. */}
+        {sending && (
+          <div className="mb-2 flex items-center gap-2 px-1 text-xs font-medium text-primary">
+            <span className="flex items-end gap-0.5">
+              <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-primary [animation-delay:-0.3s]" />
+              <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-primary [animation-delay:-0.15s]" />
+              <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-primary" />
+            </span>
+            KaleidoMind is responding… please wait
+          </div>
+        )}
+        <div
+          className={`flex items-center gap-2 rounded-xl border bg-surface-overlay/40 py-1.5 pl-3 pr-1.5 transition-colors ${
+            sending
+              ? 'border-primary/40 opacity-70'
+              : 'border-border-default focus-within:border-primary/50'
+          }`}
+        >
           <input
-            className="flex-1 bg-transparent py-1.5 text-sm text-content-primary placeholder-content-tertiary focus:outline-none disabled:opacity-50"
+            className="flex-1 bg-transparent py-1.5 text-sm text-content-primary placeholder-content-tertiary focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
             disabled={!providerOn || sending}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && send()}
             placeholder={
-              providerOn ? 'Message KaleidoMind…' : 'Start a model first'
+              sending
+                ? 'Waiting for KaleidoMind to finish…'
+                : providerOn
+                  ? 'Message KaleidoMind…'
+                  : 'Start a model first'
             }
             value={input}
           />
           <button
-            aria-label="Send message"
+            aria-label={sending ? 'KaleidoMind is responding' : 'Send message'}
             className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-primary text-surface-base transition-all hover:bg-primary-emphasis active:scale-95 disabled:opacity-40"
             disabled={!providerOn || sending || !input.trim()}
             onClick={() => send()}
             type="button"
           >
-            <Send className="h-4 w-4" />
+            {sending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
           </button>
         </div>
       </div>

--- a/src/routes/kaleido-mind/index.tsx
+++ b/src/routes/kaleido-mind/index.tsx
@@ -6,9 +6,11 @@ import { Brain, Loader2 } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 
+import { mindClient, type MindEvent } from '../../api/mind'
 import { useMind } from '../../hooks/useMind'
 
 import { StatusPill, labelForPhase, type ChatMsg } from './shared'
+import { StartBrainModal } from './start-brain-modal'
 
 export const Component: React.FC = () => {
   const mind = useMind()
@@ -29,11 +31,39 @@ export const Component: React.FC = () => {
   const [input, setInput] = useState('')
 
   useEffect(() => {
-    localStorage.setItem(
-      'kaleido-mind.chat-history.v1',
-      JSON.stringify(messages.slice(-100))
-    )
+    // Thinking/content can arrive token-by-token. Debounce persistence so live
+    // streaming does not synchronously rewrite localStorage for every token.
+    const timer = setTimeout(() => {
+      localStorage.setItem(
+        'kaleido-mind.chat-history.v1',
+        JSON.stringify(
+          messages
+            .slice(-100)
+            .map(({ streaming: _streaming, ...message }) => message)
+        )
+      )
+    }, 250)
+    return () => clearTimeout(timer)
   }, [messages])
+
+  // The agent can message you unprompted — a finished task, a liquidity alert.
+  // Those arrive as `agent_message` events and append to the conversation as
+  // assistant turns, even while you're on another Mind sub-tab.
+  useEffect(() => {
+    const off = mindClient.on((e: MindEvent) => {
+      if (e.type !== 'agent_message') return
+      setMessages((m) => [
+        ...m,
+        {
+          createdAt: e.at,
+          id: crypto.randomUUID(),
+          role: 'assistant',
+          text: e.text,
+        },
+      ])
+    })
+    return off
+  }, [])
 
   return (
     <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-6 overflow-y-auto p-6">
@@ -73,6 +103,9 @@ export const Component: React.FC = () => {
       <Outlet
         context={{ chat: { input, messages, setInput, setMessages }, mind }}
       />
+
+      {/* Offline prompt — pops up on any Mind page when the brain isn't running. */}
+      <StartBrainModal mind={mind} />
     </div>
   )
 }

--- a/src/routes/kaleido-mind/index.tsx
+++ b/src/routes/kaleido-mind/index.tsx
@@ -3,7 +3,7 @@
 // active sub-page (Brain / Pairing / Models / Skills / Chat) in the Outlet.
 
 import { Brain, Loader2 } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { useMind } from '../../hooks/useMind'
@@ -16,8 +16,24 @@ export const Component: React.FC = () => {
   const providerOn = status?.on === true
 
   // Chat state lives here so it persists across the Mind sub-tabs.
-  const [messages, setMessages] = useState<ChatMsg[]>([])
+  const [messages, setMessages] = useState<ChatMsg[]>(() => {
+    try {
+      const parsed = JSON.parse(
+        localStorage.getItem('kaleido-mind.chat-history.v1') ?? '[]'
+      )
+      return Array.isArray(parsed) ? parsed : []
+    } catch {
+      return []
+    }
+  })
   const [input, setInput] = useState('')
+
+  useEffect(() => {
+    localStorage.setItem(
+      'kaleido-mind.chat-history.v1',
+      JSON.stringify(messages.slice(-100))
+    )
+  }, [messages])
 
   return (
     <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-6 overflow-y-auto p-6">

--- a/src/routes/kaleido-mind/models.tsx
+++ b/src/routes/kaleido-mind/models.tsx
@@ -1,8 +1,8 @@
 // Models — browse the catalog, download/delete models, and start/stop the brain
 // on a given model.
 
-import { Cpu, Download, Play, Square, Trash2, X } from 'lucide-react'
-import React, { useMemo } from 'react'
+import { Cpu, Download, Plus, Play, Square, Trash2, X } from 'lucide-react'
+import React, { useMemo, useState } from 'react'
 
 import { MindCard, gb, useMindContext } from './shared'
 
@@ -10,6 +10,11 @@ export const Component: React.FC = () => {
   const mind = useMindContext()
   const { status } = mind
   const providerOn = status?.on === true
+  const [showCustom, setShowCustom] = useState(false)
+  const [repo, setRepo] = useState('')
+  const [file, setFile] = useState('')
+  const [name, setName] = useState('')
+  const [customError, setCustomError] = useState('')
 
   const installedIds = useMemo(
     () => new Set(mind.installed.map((m) => m.id)),
@@ -21,7 +26,64 @@ export const Component: React.FC = () => {
       <div className="mb-3 flex items-center gap-2">
         <Cpu className="h-5 w-5 text-gray-300" />
         <h2 className="font-semibold text-white">Models</h2>
+        <button
+          className="ml-auto flex items-center gap-1 rounded-md border border-gray-700 px-2.5 py-1 text-xs text-gray-200 hover:bg-gray-800"
+          onClick={() => setShowCustom((v) => !v)}
+          type="button"
+        >
+          <Plus className="h-3.5 w-3.5" /> Hugging Face
+        </button>
       </div>
+      {showCustom && (
+        <form
+          className="mb-4 grid gap-2 rounded-lg border border-violet-800/50 bg-violet-950/20 p-3"
+          onSubmit={(e) => {
+            e.preventDefault()
+            setCustomError('')
+            void mind
+              .addHuggingFaceModel(repo, file, name || undefined)
+              .then(() => {
+                setRepo('')
+                setFile('')
+                setName('')
+                setShowCustom(false)
+              })
+              .catch((err) =>
+                setCustomError(err instanceof Error ? err.message : String(err))
+              )
+          }}
+        >
+          <p className="text-xs text-gray-400">
+            Download any top-level GGUF from a public Hugging Face repository.
+          </p>
+          <input
+            className="rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white"
+            onChange={(e) => setRepo(e.target.value)}
+            placeholder="owner/repository"
+            value={repo}
+          />
+          <input
+            className="rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white"
+            onChange={(e) => setFile(e.target.value)}
+            placeholder="model.Q4_K_M.gguf"
+            value={file}
+          />
+          <input
+            className="rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white"
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Display name (optional)"
+            value={name}
+          />
+          {customError && <p className="text-xs text-red-400">{customError}</p>}
+          <button
+            className="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-40"
+            disabled={!repo.trim() || !file.trim()}
+            type="submit"
+          >
+            Add &amp; download
+          </button>
+        </form>
+      )}
       <div className="flex flex-col gap-2">
         {mind.catalog.length === 0 && (
           <p className="text-sm text-gray-500">Loading catalog…</p>

--- a/src/routes/kaleido-mind/models.tsx
+++ b/src/routes/kaleido-mind/models.tsx
@@ -6,13 +6,12 @@ import React, { useMemo, useState } from 'react'
 
 import { MindCard, gb, useMindContext } from './shared'
 
-export const Component: React.FC = () => {
+export const ModelsManager: React.FC = () => {
   const mind = useMindContext()
   const { status } = mind
   const providerOn = status?.on === true
   const [showCustom, setShowCustom] = useState(false)
-  const [repo, setRepo] = useState('')
-  const [file, setFile] = useState('')
+  const [url, setUrl] = useState('')
   const [name, setName] = useState('')
   const [customError, setCustomError] = useState('')
 
@@ -24,10 +23,10 @@ export const Component: React.FC = () => {
   return (
     <MindCard>
       <div className="mb-3 flex items-center gap-2">
-        <Cpu className="h-5 w-5 text-gray-300" />
-        <h2 className="font-semibold text-white">Models</h2>
+        <Cpu className="h-5 w-5 text-content-secondary" />
+        <h2 className="font-semibold text-content-primary">Models</h2>
         <button
-          className="ml-auto flex items-center gap-1 rounded-md border border-gray-700 px-2.5 py-1 text-xs text-gray-200 hover:bg-gray-800"
+          className="ml-auto flex items-center gap-1 rounded-md border border-border-default px-2.5 py-1 text-xs text-content-secondary hover:bg-surface-overlay"
           onClick={() => setShowCustom((v) => !v)}
           type="button"
         >
@@ -36,15 +35,14 @@ export const Component: React.FC = () => {
       </div>
       {showCustom && (
         <form
-          className="mb-4 grid gap-2 rounded-lg border border-violet-800/50 bg-violet-950/20 p-3"
+          className="mb-4 grid gap-2 rounded-lg border border-primary/40 bg-primary/5 p-3"
           onSubmit={(e) => {
             e.preventDefault()
             setCustomError('')
             void mind
-              .addHuggingFaceModel(repo, file, name || undefined)
+              .addHuggingFaceModel(url, name || undefined)
               .then(() => {
-                setRepo('')
-                setFile('')
+                setUrl('')
                 setName('')
                 setShowCustom(false)
               })
@@ -53,31 +51,29 @@ export const Component: React.FC = () => {
               )
           }}
         >
-          <p className="text-xs text-gray-400">
-            Download any top-level GGUF from a public Hugging Face repository.
+          <p className="text-xs text-content-tertiary">
+            Paste a public Hugging Face repository URL. Kaleido selects the
+            recommended GGUF automatically.
           </p>
           <input
-            className="rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white"
-            onChange={(e) => setRepo(e.target.value)}
-            placeholder="owner/repository"
-            value={repo}
+            className="rounded-md border border-border-default bg-surface-overlay px-3 py-2 text-sm text-content-primary"
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://huggingface.co/owner/model-GGUF"
+            type="url"
+            value={url}
           />
           <input
-            className="rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white"
-            onChange={(e) => setFile(e.target.value)}
-            placeholder="model.Q4_K_M.gguf"
-            value={file}
-          />
-          <input
-            className="rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white"
+            className="rounded-md border border-border-default bg-surface-overlay px-3 py-2 text-sm text-content-primary"
             onChange={(e) => setName(e.target.value)}
             placeholder="Display name (optional)"
             value={name}
           />
-          {customError && <p className="text-xs text-red-400">{customError}</p>}
+          {customError && (
+            <p className="text-xs text-status-danger">{customError}</p>
+          )}
           <button
-            className="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-40"
-            disabled={!repo.trim() || !file.trim()}
+            className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-surface-base disabled:opacity-40"
+            disabled={!url.trim()}
             type="submit"
           >
             Add &amp; download
@@ -86,7 +82,7 @@ export const Component: React.FC = () => {
       )}
       <div className="flex flex-col gap-2">
         {mind.catalog.length === 0 && (
-          <p className="text-sm text-gray-500">Loading catalog…</p>
+          <p className="text-sm text-content-tertiary">Loading catalog…</p>
         )}
         {mind.catalog.map((m) => {
           const isInstalled = installedIds.has(m.id)
@@ -95,21 +91,21 @@ export const Component: React.FC = () => {
           const downloading = typeof dl === 'number'
           return (
             <div
-              className="flex items-center justify-between rounded-lg border border-gray-800 bg-gray-900/60 px-3 py-2"
+              className="flex items-center justify-between rounded-lg border border-border-default bg-surface-overlay/40 px-3 py-2"
               key={m.id}
             >
               <div className="min-w-0">
                 <div className="flex items-center gap-2">
-                  <span className="truncate text-sm font-medium text-white">
+                  <span className="truncate text-sm font-medium text-content-primary">
                     {m.displayName}
                   </span>
                   {isActive && (
-                    <span className="rounded-full bg-green-600/30 px-2 py-0.5 text-[10px] font-semibold text-green-300">
+                    <span className="rounded-full bg-status-success/20 px-2 py-0.5 text-[10px] font-semibold text-status-success">
                       Running
                     </span>
                   )}
                 </div>
-                <div className="text-xs text-gray-500">
+                <div className="text-xs text-content-tertiary">
                   {m.quant} · {gb(m.sizeBytes)} · ~{m.ramHintGb} GB RAM
                 </div>
               </div>
@@ -117,11 +113,11 @@ export const Component: React.FC = () => {
               <div className="flex shrink-0 items-center gap-2">
                 {downloading ? (
                   <div className="flex items-center gap-2">
-                    <span className="w-10 text-right text-xs text-violet-300">
+                    <span className="w-10 text-right text-xs text-primary">
                       {dl}%
                     </span>
                     <button
-                      className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-red-400"
+                      className="rounded p-1 text-content-tertiary hover:bg-surface-overlay hover:text-status-danger"
                       onClick={() => mind.cancelDownload(m.id)}
                       title="Cancel"
                     >
@@ -132,14 +128,14 @@ export const Component: React.FC = () => {
                   <>
                     {isActive ? (
                       <button
-                        className="flex items-center gap-1 rounded-md bg-red-600/80 px-2.5 py-1 text-xs font-medium text-white hover:bg-red-600"
+                        className="flex items-center gap-1 rounded-md bg-status-danger px-2.5 py-1 text-xs font-medium text-white hover:bg-status-danger/90"
                         onClick={() => mind.stopProvider()}
                       >
                         <Square className="h-3.5 w-3.5" /> Stop
                       </button>
                     ) : (
                       <button
-                        className="flex items-center gap-1 rounded-md bg-violet-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-violet-500 disabled:opacity-40"
+                        className="flex items-center gap-1 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-surface-base hover:bg-primary-emphasis disabled:opacity-40"
                         disabled={providerOn}
                         onClick={() => mind.startProvider(m.id)}
                       >
@@ -147,7 +143,7 @@ export const Component: React.FC = () => {
                       </button>
                     )}
                     <button
-                      className="rounded p-1 text-gray-400 hover:bg-gray-800 hover:text-red-400 disabled:opacity-30"
+                      className="rounded p-1 text-content-tertiary hover:bg-surface-overlay hover:text-status-danger disabled:opacity-30"
                       disabled={isActive}
                       onClick={() => mind.deleteModel(m.id)}
                       title="Delete"
@@ -157,7 +153,7 @@ export const Component: React.FC = () => {
                   </>
                 ) : (
                   <button
-                    className="flex items-center gap-1 rounded-md border border-gray-700 px-2.5 py-1 text-xs text-gray-200 hover:bg-gray-800"
+                    className="flex items-center gap-1 rounded-md border border-border-default px-2.5 py-1 text-xs text-content-secondary hover:bg-surface-overlay"
                     onClick={() => mind.downloadModel(m.id)}
                   >
                     <Download className="h-3.5 w-3.5" /> Get
@@ -171,3 +167,7 @@ export const Component: React.FC = () => {
     </MindCard>
   )
 }
+
+// The standalone /kaleido-mind/models route renders the same manager that the
+// Brain page embeds as a section.
+export const Component = ModelsManager

--- a/src/routes/kaleido-mind/pairing.tsx
+++ b/src/routes/kaleido-mind/pairing.tsx
@@ -1,16 +1,24 @@
 // Pairing — show the P2P pairing QR so the phone can delegate inference to this
-// desktop brain.
+// desktop brain. `PairingPanel` is reused both as a modal (from Brain) and as
+// the standalone /kaleido-mind/pairing page (which adds a back button).
 
-import { Check, Copy, Users } from 'lucide-react'
+import { ArrowLeft, Check, Copy, Loader2, Users } from 'lucide-react'
 import { QRCodeSVG } from 'qrcode.react'
 import React, { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { KALEIDO_MIND_BRAIN_PATH } from '../../app/router/paths'
 
 import { MindCard, useMindContext } from './shared'
 
-export const Component: React.FC = () => {
+/** The QR + states, with no surrounding navigation (works in a modal or page). */
+export const PairingPanel: React.FC = () => {
   const mind = useMindContext()
   const { status } = mind
   const providerOn = status?.on === true
+  // The pubkey arrives on a separate `pubkey` event after P2P bootstraps, so the
+  // brain can be ON for a moment before the key (and QR) are ready.
+  const preparing = (providerOn && !status?.publicKey) || !!mind.loading
 
   // Structured pairing payload the phone parses (services/PairingService.ts).
   // The phone also accepts a bare public key, but the structured form carries
@@ -42,16 +50,18 @@ export const Component: React.FC = () => {
   return (
     <MindCard>
       <div className="mb-3 flex items-center gap-2">
-        <Users className="h-5 w-5 text-gray-300" />
-        <h2 className="font-semibold text-white">Pair your phone</h2>
+        <Users className="h-5 w-5 text-content-secondary" />
+        <h2 className="font-semibold text-content-primary">Pair your phone</h2>
       </div>
+
       {providerOn && status?.publicKey ? (
+        // ── Ready: show the QR ──
         <div className="flex flex-col items-center gap-3">
           <div className="rounded-lg bg-white p-3">
             <QRCodeSVG level="M" size={196} value={qrValue} />
           </div>
           <button
-            className="flex items-center gap-2 rounded-md border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+            className="flex items-center gap-2 rounded-md border border-border-default px-3 py-1.5 text-xs text-content-secondary hover:bg-surface-overlay"
             onClick={copyKey}
           >
             {copied ? (
@@ -63,23 +73,54 @@ export const Component: React.FC = () => {
               {status.publicKey.slice(0, 10)}…{status.publicKey.slice(-6)}
             </span>
           </button>
-          <p className="max-w-sm text-center text-xs text-gray-500">
+          <p className="max-w-sm text-center text-xs text-content-tertiary">
             In the KaleidoSwap app: AI → Settings → “Scan QR from desktop” (or
             paste the key).
           </p>
           {status.peers.length > 0 && (
-            <div className="mt-1 w-full max-w-sm rounded-md bg-gray-800/50 p-2 text-center text-xs text-gray-300">
+            <div className="mt-1 w-full max-w-sm rounded-md bg-surface-overlay/60 p-2 text-center text-xs text-content-secondary">
               {status.peers.length} phone
               {status.peers.length > 1 ? 's' : ''} connected
             </div>
           )}
         </div>
+      ) : preparing ? (
+        // ── Preparing: brain starting / P2P bootstrapping — loading QR ──
+        <div className="flex flex-col items-center gap-3">
+          <div className="flex h-[218px] w-[218px] flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border-default bg-surface-base/50">
+            <Loader2 className="h-7 w-7 animate-spin text-primary" />
+            <span className="text-xs text-content-tertiary">
+              {mind.loading?.message ?? 'Preparing pairing code…'}
+            </span>
+          </div>
+          <p className="max-w-sm text-center text-xs text-content-tertiary">
+            Establishing the secure P2P channel. The QR appears as soon as the
+            brain is online.
+          </p>
+        </div>
       ) : (
-        <p className="text-sm text-gray-500">
-          Start the brain with a model (Models tab) to show a pairing QR. The
+        // ── Off: prompt to start the brain ──
+        <p className="text-sm text-content-tertiary">
+          Start the brain with a model (in Brain) to show a pairing QR. The
           phone scans it to run inference here instead of on-device.
         </p>
       )}
     </MindCard>
+  )
+}
+
+export const Component: React.FC = () => {
+  const navigate = useNavigate()
+  return (
+    <div className="flex flex-col gap-4">
+      <button
+        className="inline-flex w-fit items-center gap-1.5 rounded-md border border-border-default px-2.5 py-1.5 text-sm text-content-secondary transition-colors hover:bg-surface-overlay hover:text-content-primary"
+        onClick={() => navigate(KALEIDO_MIND_BRAIN_PATH)}
+        type="button"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to Brain
+      </button>
+      <PairingPanel />
+    </div>
   )
 }

--- a/src/routes/kaleido-mind/shared.tsx
+++ b/src/routes/kaleido-mind/shared.tsx
@@ -8,13 +8,46 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { useOutletContext } from 'react-router-dom'
 
+import type { SuggestedAction } from '../../api/mind'
 import type { UseMindResult } from '../../hooks/useMind'
 
+/**
+ * A tool the agent ran during an assistant turn — rendered live as a "running"
+ * pill, then as a typed result card when it returns. Correlated back to its
+ * call by tool `name` (the sidecar fires the call event fire-and-forget, so a
+ * fast result can arrive before its call — see chat.tsx).
+ */
+export interface ChatToolEvent {
+  id: string
+  name: string
+  arguments?: Record<string, unknown>
+  status: 'running' | 'done' | 'error'
+  result?: unknown
+}
+
+/** Per-response inference stats (real QVAC numbers), shown under the answer. */
+export interface ChatMsgStats {
+  tokensPerSecond?: number
+  tokens?: number
+  promptTokens?: number
+  latencyMs?: number
+  device?: 'gpu' | 'cpu' | null
+}
+
 export interface ChatMsg {
+  id?: string
   role: 'user' | 'assistant'
   text: string
   /** The model's `<think>` reasoning for an assistant turn, shown collapsed. */
   thinking?: string
+  /** Tools the agent invoked this turn, in arrival order (cards + live pills). */
+  toolEvents?: ChatToolEvent[]
+  /** Contextual next-step cards proposed by the agent after this reply. */
+  followups?: SuggestedAction[]
+  /** tok/s, tokens used, timing for this answer (QVAC). */
+  stats?: ChatMsgStats
+  createdAt?: number
+  streaming?: boolean
 }
 
 // Chat state is owned by the layout so the conversation survives navigating
@@ -76,11 +109,13 @@ export function StatusPill({
   return (
     <div
       className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium ${
-        on ? 'bg-green-600/20 text-green-300' : 'bg-gray-700/40 text-gray-400'
+        on
+          ? 'bg-status-success/15 text-status-success'
+          : 'bg-surface-overlay text-content-tertiary'
       }`}
     >
       <span
-        className={`h-2 w-2 rounded-full ${on ? 'bg-green-400' : 'bg-gray-500'}`}
+        className={`h-2 w-2 rounded-full ${on ? 'bg-status-success' : 'bg-content-tertiary'}`}
       />
       {on ? (
         <span>
@@ -104,7 +139,7 @@ export function MindCard({
 }) {
   return (
     <section
-      className={`rounded-xl border border-gray-800 bg-gray-900/40 p-5 ${className}`}
+      className={`rounded-xl border border-border-default bg-surface-base/50 p-5 ${className}`}
     >
       {children}
     </section>

--- a/src/routes/kaleido-mind/shared.tsx
+++ b/src/routes/kaleido-mind/shared.tsx
@@ -13,6 +13,8 @@ import type { UseMindResult } from '../../hooks/useMind'
 export interface ChatMsg {
   role: 'user' | 'assistant'
   text: string
+  /** The model's `<think>` reasoning for an assistant turn, shown collapsed. */
+  thinking?: string
 }
 
 // Chat state is owned by the layout so the conversation survives navigating

--- a/src/routes/kaleido-mind/skills.tsx
+++ b/src/routes/kaleido-mind/skills.tsx
@@ -10,10 +10,16 @@ import React, { useState } from 'react'
 
 import { MindCard, useMindContext } from './shared'
 
-export const Component: React.FC = () => {
+export const SkillsManager: React.FC = () => {
   const mind = useMindContext()
   const caps = mind.capabilities
   const [showAddMcp, setShowAddMcp] = useState(false)
+  const [showAddSkill, setShowAddSkill] = useState(false)
+  const [skillName, setSkillName] = useState('')
+  const [skillDescription, setSkillDescription] = useState('')
+  const [skillInstructions, setSkillInstructions] = useState('')
+  const [skillTools, setSkillTools] = useState('')
+  const [skillError, setSkillError] = useState('')
   const [mcpName, setMcpName] = useState('')
   const [mcpUrl, setMcpUrl] = useState('')
   const [mcpError, setMcpError] = useState('')
@@ -21,10 +27,10 @@ export const Component: React.FC = () => {
     <div className="flex flex-col gap-6">
       <MindCard>
         <div className="mb-3 flex items-center gap-2">
-          <Sparkles className="h-5 w-5 text-gray-300" />
-          <h2 className="font-semibold text-white">Skills & tools</h2>
+          <Sparkles className="h-5 w-5 text-content-secondary" />
+          <h2 className="font-semibold text-content-primary">Skills & tools</h2>
         </div>
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-content-tertiary">
           {caps?.mcpConnected
             ? `Live registry: ${caps.skills.length} skills and ${caps.tools.length} tools.`
             : 'The skill registry is available, but the Kaleido MCP is not connected.'}
@@ -33,55 +39,164 @@ export const Component: React.FC = () => {
 
       <MindCard>
         <div className="mb-3 flex items-center gap-2">
-          <Wrench className="h-5 w-5 text-amber-300" />
-          <h3 className="font-semibold text-white">Skills</h3>
+          <Wrench className="h-5 w-5 text-status-warning" />
+          <h3 className="font-semibold text-content-primary">Skills</h3>
+          <button
+            className="ml-auto flex items-center gap-1 rounded-md border border-border-default px-2.5 py-1 text-xs text-content-secondary hover:bg-surface-overlay"
+            onClick={() => setShowAddSkill((value) => !value)}
+            type="button"
+          >
+            <Plus className="h-3.5 w-3.5" /> Add skill
+          </button>
         </div>
+        {showAddSkill && (
+          <form
+            className="mb-4 grid gap-2 rounded-lg border border-status-warning/40 bg-status-warning/10 p-3"
+            onSubmit={(event) => {
+              event.preventDefault()
+              setSkillError('')
+              void mind
+                .addSkill(
+                  skillName,
+                  skillDescription,
+                  skillInstructions,
+                  skillTools
+                    .split(',')
+                    .map((tool) => tool.trim())
+                    .filter(Boolean)
+                )
+                .then(() => {
+                  setSkillName('')
+                  setSkillDescription('')
+                  setSkillInstructions('')
+                  setSkillTools('')
+                  setShowAddSkill(false)
+                })
+                .catch((error) =>
+                  setSkillError(
+                    error instanceof Error ? error.message : String(error)
+                  )
+                )
+            }}
+          >
+            <input
+              className="rounded-md border border-border-default bg-surface-overlay px-3 py-2 text-sm text-content-primary"
+              onChange={(event) => setSkillName(event.target.value)}
+              placeholder="Skill name"
+              value={skillName}
+            />
+            <input
+              className="rounded-md border border-border-default bg-surface-overlay px-3 py-2 text-sm text-content-primary"
+              onChange={(event) => setSkillDescription(event.target.value)}
+              placeholder="When should the model use this skill?"
+              value={skillDescription}
+            />
+            <textarea
+              className="min-h-32 rounded-md border border-border-default bg-surface-overlay px-3 py-2 text-sm text-content-primary"
+              onChange={(event) => setSkillInstructions(event.target.value)}
+              placeholder="Instructions for the model…"
+              value={skillInstructions}
+            />
+            <input
+              className="rounded-md border border-border-default bg-surface-overlay px-3 py-2 text-sm text-content-primary"
+              onChange={(event) => setSkillTools(event.target.value)}
+              placeholder="Optional tools, comma separated"
+              value={skillTools}
+            />
+            {skillError && (
+              <p className="text-xs text-status-danger">{skillError}</p>
+            )}
+            <button
+              className="rounded-md bg-status-warning px-3 py-2 text-sm font-medium text-white disabled:opacity-40"
+              disabled={
+                !skillName.trim() ||
+                !skillDescription.trim() ||
+                !skillInstructions.trim()
+              }
+              type="submit"
+            >
+              Save skill
+            </button>
+          </form>
+        )}
         <div className="space-y-2">
           {caps?.skills.map((skill) => (
             <div
-              className="flex items-start gap-3 rounded-lg border border-gray-800 bg-gray-950/40 p-3"
+              className="flex items-start gap-3 rounded-lg border border-border-default bg-surface-overlay/40 p-3"
               key={skill.name}
             >
               <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-white">{skill.name}</p>
-                <p className="mt-0.5 text-xs text-gray-500">
+                <p className="text-sm font-medium text-content-primary">
+                  {skill.name}
+                </p>
+                <p className="mt-0.5 text-xs text-content-tertiary">
                   {skill.description}
                 </p>
-                <p className="mt-1 truncate font-mono text-[10px] text-gray-600">
+                <p className="mt-1 truncate font-mono text-[10px] text-content-tertiary">
                   {skill.tools.join(' · ') || 'No scoped tools'}
                 </p>
               </div>
-              <button
-                aria-pressed={skill.enabled}
-                className={`rounded-full px-3 py-1 text-xs font-semibold ${
-                  skill.enabled
-                    ? 'bg-green-600/20 text-green-300'
-                    : 'bg-gray-800 text-gray-400'
-                }`}
-                onClick={() =>
-                  void mind.setSkillEnabled(skill.name, !skill.enabled)
-                }
-                type="button"
-              >
-                {skill.enabled ? 'Enabled' : 'Disabled'}
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  aria-pressed={skill.enabled}
+                  className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                    skill.enabled
+                      ? 'bg-status-success/15 text-status-success'
+                      : 'bg-surface-overlay text-content-tertiary'
+                  }`}
+                  onClick={() => {
+                    setSkillError('')
+                    void mind
+                      .setSkillEnabled(skill.name, !skill.enabled)
+                      .catch((error) =>
+                        setSkillError(
+                          error instanceof Error ? error.message : String(error)
+                        )
+                      )
+                  }}
+                  type="button"
+                >
+                  {skill.enabled ? 'Enabled' : 'Disabled'}
+                </button>
+                <button
+                  className="rounded p-1 text-content-tertiary hover:bg-surface-overlay hover:text-status-danger"
+                  onClick={() => {
+                    if (
+                      window.confirm(
+                        `Delete "${skill.name}"? Built-in skills can be restored by reinstalling or re-adding them.`
+                      )
+                    ) {
+                      void mind.deleteSkill(skill.name)
+                    }
+                  }}
+                  title={`Delete ${skill.name}`}
+                  type="button"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
             </div>
           ))}
+          {skillError && !showAddSkill && (
+            <p className="text-xs text-status-danger">{skillError}</p>
+          )}
           {!caps?.skills.length && (
-            <p className="text-sm text-gray-500">No skills loaded.</p>
+            <p className="text-sm text-content-tertiary">No skills loaded.</p>
           )}
         </div>
       </MindCard>
 
       <MindCard>
         <div className="mb-3 flex items-center gap-2">
-          <Network className="h-5 w-5 text-violet-300" />
-          <h3 className="font-semibold text-white">MCP servers &amp; tools</h3>
-          <span className="ml-auto hidden text-xs text-gray-500 sm:inline">
+          <Network className="h-5 w-5 text-primary" />
+          <h3 className="font-semibold text-content-primary">
+            MCP servers &amp; tools
+          </h3>
+          <span className="ml-auto hidden text-xs text-content-tertiary sm:inline">
             {caps?.tools.length ?? 0} connected
           </span>
           <button
-            className="flex items-center gap-1 rounded-md border border-gray-700 px-2.5 py-1 text-xs text-gray-200 hover:bg-gray-800"
+            className="flex items-center gap-1 rounded-md border border-border-default px-2.5 py-1 text-xs text-content-secondary hover:bg-surface-overlay"
             onClick={() => setShowAddMcp((v) => !v)}
             type="button"
           >
@@ -90,7 +205,7 @@ export const Component: React.FC = () => {
         </div>
         {showAddMcp && (
           <form
-            className="mb-4 grid gap-2 rounded-lg border border-violet-800/50 bg-violet-950/20 p-3"
+            className="mb-4 grid gap-2 rounded-lg border border-primary/40 bg-primary/5 p-3"
             onSubmit={(event) => {
               event.preventDefault()
               setMcpError('')
@@ -109,21 +224,23 @@ export const Component: React.FC = () => {
             }}
           >
             <input
-              className="rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white"
+              className="rounded-md border border-border-default bg-surface-overlay px-3 py-2 text-sm text-content-primary"
               onChange={(event) => setMcpName(event.target.value)}
               placeholder="Server name"
               value={mcpName}
             />
             <input
-              className="rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white"
+              className="rounded-md border border-border-default bg-surface-overlay px-3 py-2 text-sm text-content-primary"
               onChange={(event) => setMcpUrl(event.target.value)}
               placeholder="https://example.com/mcp"
               type="url"
               value={mcpUrl}
             />
-            {mcpError && <p className="text-xs text-red-400">{mcpError}</p>}
+            {mcpError && (
+              <p className="text-xs text-status-danger">{mcpError}</p>
+            )}
             <button
-              className="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-40"
+              className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-surface-base disabled:opacity-40"
               disabled={!mcpName.trim() || !mcpUrl.trim()}
               type="submit"
             >
@@ -135,20 +252,26 @@ export const Component: React.FC = () => {
         <div className="mb-4 space-y-2">
           {caps?.mcpServers.map((server) => (
             <div
-              className="flex items-center gap-3 rounded-lg border border-gray-800 bg-gray-950/40 p-3"
+              className="flex items-center gap-3 rounded-lg border border-border-default bg-surface-overlay/40 p-3"
               key={server.id}
             >
               <span
                 className={`h-2 w-2 shrink-0 rounded-full ${
-                  server.connected ? 'bg-green-400' : 'bg-red-400'
+                  server.connected ? 'bg-status-success' : 'bg-status-danger'
                 }`}
               />
               <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-white">{server.name}</p>
-                <p className="truncate text-xs text-gray-500">{server.url}</p>
+                <p className="text-sm font-medium text-content-primary">
+                  {server.name}
+                </p>
+                <p className="truncate text-xs text-content-tertiary">
+                  {server.url}
+                </p>
                 <p
                   className={`text-[10px] ${
-                    server.connected ? 'text-green-400' : 'text-red-400'
+                    server.connected
+                      ? 'text-status-success'
+                      : 'text-status-danger'
                   }`}
                 >
                   {server.connected
@@ -157,7 +280,7 @@ export const Component: React.FC = () => {
                 </p>
               </div>
               <button
-                className="rounded p-1 text-gray-500 hover:bg-gray-800 hover:text-red-400"
+                className="rounded p-1 text-content-tertiary hover:bg-surface-overlay hover:text-status-danger"
                 onClick={() => void mind.removeMcpServer(server.id)}
                 title={`Remove ${server.name}`}
                 type="button"
@@ -171,18 +294,18 @@ export const Component: React.FC = () => {
         <div className="grid gap-2 sm:grid-cols-2">
           {caps?.tools.map((tool) => (
             <div
-              className="rounded-lg border border-gray-800 bg-gray-950/40 p-3"
+              className="rounded-lg border border-border-default bg-surface-overlay/40 p-3"
               key={tool.name}
             >
               <div className="flex items-center gap-2">
-                <p className="truncate font-mono text-xs text-white">
+                <p className="truncate font-mono text-xs text-content-primary">
                   {tool.name}
                 </p>
                 {tool.requiresConfirmation && (
-                  <ShieldCheck className="h-3.5 w-3.5 shrink-0 text-amber-300" />
+                  <ShieldCheck className="h-3.5 w-3.5 shrink-0 text-status-warning" />
                 )}
               </div>
-              <p className="mt-1 line-clamp-2 text-xs text-gray-500">
+              <p className="mt-1 line-clamp-2 text-xs text-content-tertiary">
                 {tool.description}
               </p>
             </div>
@@ -192,3 +315,7 @@ export const Component: React.FC = () => {
     </div>
   )
 }
+
+// The standalone /kaleido-mind/skills route renders the same manager that the
+// Brain page embeds as a section.
+export const Component = SkillsManager

--- a/src/routes/kaleido-mind/skills.tsx
+++ b/src/routes/kaleido-mind/skills.tsx
@@ -1,31 +1,22 @@
-// Skills — overview of what the agent can do. Chat routes through skills and
-// the connected MCP tools. There is no skills API in the sidecar yet, so this
-// page is an overview/placeholder ready to be wired to a real registry.
+import {
+  Network,
+  Plus,
+  ShieldCheck,
+  Sparkles,
+  Trash2,
+  Wrench,
+} from 'lucide-react'
+import React, { useState } from 'react'
 
-import { Network, Sparkles, Wallet, Wrench } from 'lucide-react'
-import React from 'react'
-
-import { MindCard } from './shared'
-
-const CAPABILITIES = [
-  {
-    desc: 'Inspect balances, channels, invoices and on-chain activity on the connected RGB Lightning node.',
-    icon: <Wallet className="h-5 w-5 text-cyan-300" />,
-    title: 'Node & wallet',
-  },
-  {
-    desc: 'Reach external tools and data sources exposed over the Model Context Protocol.',
-    icon: <Network className="h-5 w-5 text-violet-300" />,
-    title: 'Connected MCP tools',
-  },
-  {
-    desc: 'Task-specific skills the agent can invoke while answering. Management UI is coming soon.',
-    icon: <Wrench className="h-5 w-5 text-amber-300" />,
-    title: 'Skills',
-  },
-]
+import { MindCard, useMindContext } from './shared'
 
 export const Component: React.FC = () => {
+  const mind = useMindContext()
+  const caps = mind.capabilities
+  const [showAddMcp, setShowAddMcp] = useState(false)
+  const [mcpName, setMcpName] = useState('')
+  const [mcpUrl, setMcpUrl] = useState('')
+  const [mcpError, setMcpError] = useState('')
   return (
     <div className="flex flex-col gap-6">
       <MindCard>
@@ -34,27 +25,170 @@ export const Component: React.FC = () => {
           <h2 className="font-semibold text-white">Skills & tools</h2>
         </div>
         <p className="text-sm text-gray-500">
-          When you chat, the agent routes your request through its skills and
-          the connected MCP tools, picking the right capability for the task.
+          {caps?.mcpConnected
+            ? `Live registry: ${caps.skills.length} skills and ${caps.tools.length} tools.`
+            : 'The skill registry is available, but the Kaleido MCP is not connected.'}
         </p>
       </MindCard>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        {CAPABILITIES.map((c) => (
-          <MindCard key={c.title}>
-            <div className="mb-2 flex items-center gap-2">
-              {c.icon}
-              <h3 className="font-semibold text-white">{c.title}</h3>
+      <MindCard>
+        <div className="mb-3 flex items-center gap-2">
+          <Wrench className="h-5 w-5 text-amber-300" />
+          <h3 className="font-semibold text-white">Skills</h3>
+        </div>
+        <div className="space-y-2">
+          {caps?.skills.map((skill) => (
+            <div
+              className="flex items-start gap-3 rounded-lg border border-gray-800 bg-gray-950/40 p-3"
+              key={skill.name}
+            >
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-white">{skill.name}</p>
+                <p className="mt-0.5 text-xs text-gray-500">
+                  {skill.description}
+                </p>
+                <p className="mt-1 truncate font-mono text-[10px] text-gray-600">
+                  {skill.tools.join(' · ') || 'No scoped tools'}
+                </p>
+              </div>
+              <button
+                aria-pressed={skill.enabled}
+                className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                  skill.enabled
+                    ? 'bg-green-600/20 text-green-300'
+                    : 'bg-gray-800 text-gray-400'
+                }`}
+                onClick={() =>
+                  void mind.setSkillEnabled(skill.name, !skill.enabled)
+                }
+                type="button"
+              >
+                {skill.enabled ? 'Enabled' : 'Disabled'}
+              </button>
             </div>
-            <p className="text-xs leading-relaxed text-gray-500">{c.desc}</p>
-          </MindCard>
-        ))}
-      </div>
+          ))}
+          {!caps?.skills.length && (
+            <p className="text-sm text-gray-500">No skills loaded.</p>
+          )}
+        </div>
+      </MindCard>
 
-      <p className="text-center text-xs text-gray-600">
-        Per-skill configuration and a live tool registry will appear here in a
-        future update.
-      </p>
+      <MindCard>
+        <div className="mb-3 flex items-center gap-2">
+          <Network className="h-5 w-5 text-violet-300" />
+          <h3 className="font-semibold text-white">MCP servers &amp; tools</h3>
+          <span className="ml-auto hidden text-xs text-gray-500 sm:inline">
+            {caps?.tools.length ?? 0} connected
+          </span>
+          <button
+            className="flex items-center gap-1 rounded-md border border-gray-700 px-2.5 py-1 text-xs text-gray-200 hover:bg-gray-800"
+            onClick={() => setShowAddMcp((v) => !v)}
+            type="button"
+          >
+            <Plus className="h-3.5 w-3.5" /> Add server
+          </button>
+        </div>
+        {showAddMcp && (
+          <form
+            className="mb-4 grid gap-2 rounded-lg border border-violet-800/50 bg-violet-950/20 p-3"
+            onSubmit={(event) => {
+              event.preventDefault()
+              setMcpError('')
+              void mind
+                .addMcpServer(mcpName, mcpUrl)
+                .then(() => {
+                  setMcpName('')
+                  setMcpUrl('')
+                  setShowAddMcp(false)
+                })
+                .catch((error) =>
+                  setMcpError(
+                    error instanceof Error ? error.message : String(error)
+                  )
+                )
+            }}
+          >
+            <input
+              className="rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white"
+              onChange={(event) => setMcpName(event.target.value)}
+              placeholder="Server name"
+              value={mcpName}
+            />
+            <input
+              className="rounded-md border border-gray-700 bg-gray-950 px-3 py-2 text-sm text-white"
+              onChange={(event) => setMcpUrl(event.target.value)}
+              placeholder="https://example.com/mcp"
+              type="url"
+              value={mcpUrl}
+            />
+            {mcpError && <p className="text-xs text-red-400">{mcpError}</p>}
+            <button
+              className="rounded-md bg-violet-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-40"
+              disabled={!mcpName.trim() || !mcpUrl.trim()}
+              type="submit"
+            >
+              Connect server
+            </button>
+          </form>
+        )}
+
+        <div className="mb-4 space-y-2">
+          {caps?.mcpServers.map((server) => (
+            <div
+              className="flex items-center gap-3 rounded-lg border border-gray-800 bg-gray-950/40 p-3"
+              key={server.id}
+            >
+              <span
+                className={`h-2 w-2 shrink-0 rounded-full ${
+                  server.connected ? 'bg-green-400' : 'bg-red-400'
+                }`}
+              />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-white">{server.name}</p>
+                <p className="truncate text-xs text-gray-500">{server.url}</p>
+                <p
+                  className={`text-[10px] ${
+                    server.connected ? 'text-green-400' : 'text-red-400'
+                  }`}
+                >
+                  {server.connected
+                    ? `${server.toolCount} tools`
+                    : server.error || 'Disconnected'}
+                </p>
+              </div>
+              <button
+                className="rounded p-1 text-gray-500 hover:bg-gray-800 hover:text-red-400"
+                onClick={() => void mind.removeMcpServer(server.id)}
+                title={`Remove ${server.name}`}
+                type="button"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2">
+          {caps?.tools.map((tool) => (
+            <div
+              className="rounded-lg border border-gray-800 bg-gray-950/40 p-3"
+              key={tool.name}
+            >
+              <div className="flex items-center gap-2">
+                <p className="truncate font-mono text-xs text-white">
+                  {tool.name}
+                </p>
+                {tool.requiresConfirmation && (
+                  <ShieldCheck className="h-3.5 w-3.5 shrink-0 text-amber-300" />
+                )}
+              </div>
+              <p className="mt-1 line-clamp-2 text-xs text-gray-500">
+                {tool.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </MindCard>
     </div>
   )
 }

--- a/src/routes/kaleido-mind/start-brain-modal.tsx
+++ b/src/routes/kaleido-mind/start-brain-modal.tsx
@@ -1,0 +1,146 @@
+// A prompt that pops up whenever you're in the Mind section and the brain is
+// offline, offering to start the latest model in one tap. Rendered by the Mind
+// layout so it covers every Mind sub-page; dismissible, and auto-closes once the
+// brain comes online (or while it's loading).
+
+import { Cpu, Play, Rocket } from 'lucide-react'
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { KALEIDO_MIND_BRAIN_PATH } from '../../app/router/paths'
+import { Modal } from '../../components/ui/Modal'
+import type { UseMindResult } from '../../hooks/useMind'
+
+/** Remembers the last model you started, so "the latest" is the one you used. */
+export const LAST_MODEL_KEY = 'kaleido-mind.last-model.v1'
+
+export const StartBrainModal: React.FC<{ mind: UseMindResult }> = ({
+  mind,
+}) => {
+  const navigate = useNavigate()
+  const { status, installed, loading } = mind
+  const providerOn = status?.on === true
+  const [dismissed, setDismissed] = useState(false)
+  const [starting, setStarting] = useState(false)
+  const [selected, setSelected] = useState('')
+
+  // "Latest" = the model you last ran (persisted), else the first installed
+  // (the catalog lists the recommended model first).
+  let lastId: string | null = null
+  try {
+    lastId = localStorage.getItem(LAST_MODEL_KEY)
+  } catch {
+    /* ignore */
+  }
+  const defaultId =
+    (lastId && installed.some((m) => m.id === lastId)
+      ? lastId
+      : installed[0]?.id) ?? ''
+  const modelId = selected || defaultId
+  const activeModel = installed.find((m) => m.id === modelId)
+
+  // Show once the sidecar has reported status (avoid flashing during boot) and
+  // the brain is off, idle, not mid-start, and not dismissed this visit.
+  const open =
+    status !== null && !providerOn && !loading && !starting && !dismissed
+
+  const start = () => {
+    if (!modelId) return
+    setStarting(true)
+    try {
+      localStorage.setItem(LAST_MODEL_KEY, modelId)
+    } catch {
+      /* ignore */
+    }
+    // loading/providerOn flips → modal stays closed. On failure, allow a retry.
+    void mind.startProvider(modelId).catch(() => setStarting(false))
+  }
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={() => setDismissed(true)}
+      size="sm"
+      title="Start KaleidoMind"
+    >
+      <div className="space-y-4 p-4">
+        <div className="flex items-start gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/15 text-primary">
+            <Rocket className="h-5 w-5" />
+          </span>
+          <p className="text-sm text-content-secondary">
+            Your brain is offline. Start a model to chat, run skills, and pair
+            your phone.
+          </p>
+        </div>
+
+        {installed.length > 0 ? (
+          <>
+            {installed.length > 1 && (
+              <label className="block">
+                <span className="mb-1 block text-xs text-content-tertiary">
+                  Model
+                </span>
+                <select
+                  className="w-full rounded-lg border border-border-default bg-surface-overlay px-3 py-2 text-sm text-content-primary focus:border-primary focus:outline-none"
+                  onChange={(e) => setSelected(e.target.value)}
+                  value={modelId}
+                >
+                  {installed.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.displayName || m.id}
+                      {m.id === lastId ? ' · last used' : ''}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+            <div className="flex gap-2">
+              <button
+                className="flex-1 rounded-lg border border-border-default px-3 py-2 text-sm text-content-secondary transition-colors hover:bg-surface-overlay"
+                onClick={() => setDismissed(true)}
+                type="button"
+              >
+                Not now
+              </button>
+              <button
+                className="flex-[1.4] inline-flex items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-surface-base transition-all hover:bg-primary-emphasis active:scale-95 disabled:opacity-50"
+                disabled={!modelId}
+                onClick={start}
+                type="button"
+              >
+                <Play className="h-4 w-4" />
+                Start {activeModel?.displayName ?? 'brain'}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="text-xs text-content-tertiary">
+              No model is installed yet — grab one to bring the brain online.
+            </p>
+            <div className="flex gap-2">
+              <button
+                className="flex-1 rounded-lg border border-border-default px-3 py-2 text-sm text-content-secondary transition-colors hover:bg-surface-overlay"
+                onClick={() => setDismissed(true)}
+                type="button"
+              >
+                Not now
+              </button>
+              <button
+                className="flex-1 inline-flex items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-semibold text-surface-base transition-all hover:bg-primary-emphasis active:scale-95"
+                onClick={() => {
+                  setDismissed(true)
+                  navigate(KALEIDO_MIND_BRAIN_PATH)
+                }}
+                type="button"
+              >
+                <Cpu className="h-4 w-4" /> Get a model
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/src/routes/kaleido-mind/welcome-actions.tsx
+++ b/src/routes/kaleido-mind/welcome-actions.tsx
@@ -1,0 +1,140 @@
+// WelcomeActions — the agent's four starter actions, shown as cards on the
+// empty chat (the agent's "first message"). Defaults render offline; once a
+// model is online the provider supplies its own via get_suggested_actions
+// (wallet / node / portfolio / trade), keeping the cards capability-aware.
+
+import {
+  ArrowLeftRight,
+  Network,
+  PieChart,
+  Sparkles,
+  Wallet,
+  type LucideIcon,
+} from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+
+import { mindClient, type SuggestedAction } from '../../api/mind'
+
+/** Lucide icon per suggested-action `icon` key. */
+const ACTION_ICONS: Record<string, LucideIcon> = {
+  node: Network,
+  portfolio: PieChart,
+  trade: ArrowLeftRight,
+  wallet: Wallet,
+}
+
+/** Offline defaults — the same four the provider returns when a model is up. */
+const DEFAULT_ACTIONS: SuggestedAction[] = [
+  {
+    icon: 'wallet',
+    id: 'balance',
+    prompt: "What's my balance?",
+    subtitle: 'BTC, USDT & XAUT across your node',
+    title: 'Check my balances',
+  },
+  {
+    icon: 'node',
+    id: 'node',
+    prompt: 'How are my channels and node doing?',
+    subtitle: 'Channels, liquidity and pending transfers',
+    title: 'Node & channel health',
+  },
+  {
+    icon: 'portfolio',
+    id: 'portfolio',
+    prompt: 'Review my portfolio allocation and suggest a rebalance',
+    subtitle: 'Check drift vs targets and suggest a rebalance',
+    title: 'Optimize my portfolio',
+  },
+  {
+    icon: 'trade',
+    id: 'buy',
+    prompt: 'Buy 100 USDT',
+    subtitle: 'Quote and open an asset channel',
+    title: 'Buy 100 USDT',
+  },
+]
+
+/**
+ * Compact next-step buttons rendered UNDER an assistant reply — the agent's
+ * proposed follow-ups (provided per-turn by the sidecar). One tap continues.
+ */
+export const FollowupActions: React.FC<{
+  actions: SuggestedAction[]
+  disabled: boolean
+  onPick: (prompt: string) => void
+}> = ({ actions, disabled, onPick }) => {
+  if (!actions.length) return null
+  return (
+    <div className="mt-2.5 flex flex-wrap gap-1.5">
+      {actions.map((a) => {
+        const Icon = ACTION_ICONS[a.icon] ?? Sparkles
+        return (
+          <button
+            className="inline-flex items-center gap-1.5 rounded-full border border-border-default bg-surface-overlay/50 px-3 py-1.5 text-xs font-medium text-content-secondary transition-all hover:-translate-y-0.5 hover:border-primary/40 hover:text-content-primary disabled:opacity-40 disabled:hover:translate-y-0"
+            disabled={disabled}
+            key={a.id}
+            onClick={() => onPick(a.prompt)}
+            type="button"
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {a.title}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export const WelcomeActions: React.FC<{
+  providerOn: boolean
+  disabled: boolean
+  onPick: (prompt: string) => void
+}> = ({ disabled, onPick, providerOn }) => {
+  const [actions, setActions] = useState<SuggestedAction[]>(DEFAULT_ACTIONS)
+
+  // Ask the agent for its own starters once a model is online; fall back to the
+  // defaults on any error so the first screen is never empty.
+  useEffect(() => {
+    if (!providerOn) return
+    let alive = true
+    mindClient
+      .getSuggestedActions()
+      .then((a) => {
+        if (alive && Array.isArray(a) && a.length) setActions(a)
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [providerOn])
+
+  return (
+    <div className="mt-5 grid w-full max-w-md grid-cols-1 gap-2.5 sm:grid-cols-2">
+      {actions.map((a) => {
+        const Icon = ACTION_ICONS[a.icon] ?? Sparkles
+        return (
+          <button
+            className="group flex items-start gap-3 rounded-xl border border-border-default bg-surface-overlay/50 p-3 text-left transition-all hover:-translate-y-0.5 hover:border-primary/40 hover:bg-surface-overlay disabled:opacity-40 disabled:hover:translate-y-0"
+            disabled={disabled}
+            key={a.id}
+            onClick={() => onPick(a.prompt)}
+            type="button"
+          >
+            <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary">
+              <Icon className="h-[1.05rem] w-[1.05rem]" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-content-primary">
+                {a.title}
+              </p>
+              <p className="mt-0.5 text-xs leading-snug text-content-tertiary">
+                {a.subtitle}
+              </p>
+            </div>
+          </button>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
Consolidated KaleidoMind work for **v0.5**, rebased on latest `dev`. Supersedes #118 (packaging scaffold).

## What's in here (6 commits)

1. **`build(mind)`: packaged-build bundling scaffold** _(was #118)_ — `prepare-mind-bundle.mjs` (`pnpm bundle:mind`) stages the pruned provider + `kaleido-mcp` + a per-platform Node runtime into `src-tauri/resources/mind/`; `tauri.conf.json` ships it; `main.rs` points the sidecar env at the bundled tree (existence-checked, safe no-op in dev).
2. **`feat(mind)`: collapsible "thinking" view** — each agent reply gets a "Show thinking" toggle that expands the model's `<think>` reasoning (hidden by default). Needs the matching kaleido-mind provider change to populate `thinking`; degrades gracefully otherwise.
3. **Expand Kaleido Mind controls & model status** — richer model/brain status surfacing and skills controls.
4. **`feat(mind)`: agent control surface, typed chat cards & onboarding**
   - `agent.tsx` — autonomy surface: scheduler tasks, arm/disarm, run history + cost, dry-run / risk-limit spend gate.
   - `cards.tsx` — typed result cards per tool (balance, channels, invoice, node info, buy-asset, merchant locations…), defensive fallback for unknown/drifting shapes.
   - `start-brain-modal.tsx` — one-tap "start the latest model" prompt when the brain is offline in the Mind section.
   - `welcome-actions.tsx` — capability-aware starter cards on the empty chat.
5. **`style(mind)`: cargo fmt** the bundled-resource probe in `main.rs` (backend CI `cargo fmt --check` fix; format-only).
6. **`fix(mind)`: make `prepare-mind-bundle` run end-to-end** — exercising the scaffold surfaced three crashes, all fixed (see below).

## RLN-only
The desktop wallet is RLN-only — no WDK dependency. The sidecar keeps WDK/Spark tool aliases out of the model prompt (`KALEIDO_MIND_RLN_ONLY`), and the chat cards map any `wdk_*` tool name to its `rln_*` card defensively. `kaleido-sdk` is `^0.1.11` (latest; required `RefreshRequest.filter` retained accordingly).

## Bundle pipeline — now validated locally ✅
`pnpm bundle:mind` previously crashed; it now stages a complete tree (provider w/ `@kaleidorg/mind` + `@qvac/sdk`, `mcp/dist`, Node v20.18.1). Fixes:
- **provider deploy** — `kaleido-mind` pins pnpm@9.0.0 (predates `deploy --legacy`); run pnpm with version-switching disabled so the host pnpm (which supports `--legacy`, the only mode yielding a self-contained `node_modules`) is used.
- **mcp install** — `kaleido-mcp`'s committed lockfile lags its `package.json`, so `npm ci` refuses; fall back to `npm install` (lockfile regen tracked as a follow-up in that repo).
- **`.gitkeep`** — `reset()` no longer wipes the tracked placeholder.

## ⚠️ Release blocker (tracked separately, not in this PR's diff)
The staged bundle is **~5.4 GB** — `@qvac/sdk` hard-depends on *every* inference engine (llamacpp, whisper, diffusion, tts, ocr, vla…), but the text agent only needs the LLM engine. Trimming to LLM-only (well under 1 GB), validated by running the model, is required before shipping KaleidoMind bundled. Bundle artifacts are gitignored, so this does **not** block merging this PR.

## Validation (local, on top of `dev`)
- `pnpm type-check` ✓ · `pnpm build` ✓ · `pnpm lint` 0 errors · `pnpm test:run` **1087 passed** · `cargo check` + `cargo fmt --check` ✓
- `pnpm bundle:mind` stages a complete, runnable tree ✓
- CI: PR Checks green on the pre-bundle-fix commit (the bundle script isn't exercised by CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
