### PR TITLE
chore(release): bump to v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop-app",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "kaleidoswap"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaleidoswap"
-version = "0.4.0"
+version = "0.5.0"
 description = "Kaleidoswap App"
 authors = ["Kaleidoswap Team"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,7 +49,7 @@
   },
   "productName": "KaleidoSwap",
   "mainBinaryName": "KaleidoSwap",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "com.kaleidoswap.dev",
   "plugins": {
     "updater": {


### PR DESCRIPTION
Version bump 0.4.0 → 0.5.0 across package.json, tauri.conf.json, Cargo.toml + Cargo.lock. Prep for the v0.5.0 release (dev→main PR to follow). cargo check compiles kaleidoswap v0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)