### PR TITLE
feat(mind): bundle the agent from npm, not local sibling repos

### DIFF
--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -3,25 +3,22 @@
  * prepare-mind-bundle — stage the KaleidoMind agent for a PACKAGED build.
  *
  * Run this BEFORE `tauri build`. It produces `src-tauri/resources/mind/`:
- *   provider/   — @kaleidorg/mind-provider, prod-pruned (the model sidecar)
- *   mcp/        — kaleido-mcp, prod-pruned (the tool server)
+ *   provider/   — @kaleidorg/mind-provider (+ @qvac/sdk), installed from npm
+ *   mcp/        — kaleido-mcp, installed from npm
  *   node[.exe]  — a Node runtime for the TARGET platform
  *
- * `bundle.resources` in tauri.conf.json ships `resources/mind`, and the Rust
- * setup hook (main.rs) points KALEIDO_MIND_PROVIDER_DIR / KALEIDO_MCP_PATH /
- * KALEIDO_NODE_BIN at it. In dev none of this runs — the sidecar uses the
- * sibling repos + system node.
+ * Everything is pulled from the public npm registry — NO local sibling repos
+ * are required, so this works in clean checkouts / CI / cloud builds. Each
+ * package lands at `<name>/node_modules/<pkg>/dist/index.js` (npm's hoisted
+ * layout); main.rs probes that path and points the sidecar env at it. In dev
+ * none of this runs — the sidecar uses the sibling repos + system node.
  *
- * ⚠️  SCAFFOLD — must be validated with a real per-platform `tauri build`:
- *   - The provider drags in @qvac/sdk's NATIVE modules; confirm the pruned tree
- *     still loads the model on each target (the .node binaries are
- *     platform-specific, so build on/for each platform).
- *   - Confirm the bundled Node version is compatible with @qvac/sdk.
- *   - Measure the result (`du -sh resources/mind`) — if it's too large,
- *     esbuild-bundle the provider/mcp JS first and keep only native modules.
+ * ⚠️  The provider drags in @qvac/sdk's native engines, so the tree is large.
+ *   Measure it (`du -sh resources/mind`) and trim unused engines before relying
+ *   on it for a shipped build. Confirm the model loads on each target.
  *
- * Env knobs: NODE_VERSION (default below), MIND_REPO / MCP_REPO (sibling paths),
- * TARGET_PLATFORM / TARGET_ARCH (override host detection for cross-builds).
+ * Env knobs: PROVIDER_VERSION / MCP_VERSION / QVAC_VERSION (npm semver ranges),
+ * NODE_VERSION, TARGET_PLATFORM / TARGET_ARCH (override host detection).
  */
 import { execFileSync } from 'node:child_process'
 import {
@@ -37,26 +34,19 @@ import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
 
 const NODE_VERSION = process.env.NODE_VERSION ?? '20.18.1' // pin; match CI
+const PROVIDER_VERSION = process.env.PROVIDER_VERSION ?? '^0.6.0'
+const MCP_VERSION = process.env.MCP_VERSION ?? '^0.2.0'
+const QVAC_VERSION = process.env.QVAC_VERSION ?? '^0.13.5'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const srcTauri = resolve(here, '..')
-const repoRoot = resolve(srcTauri, '..', '..') // …/Kaleidoswap
-const mindRepo = process.env.MIND_REPO ?? join(repoRoot, 'kaleido-mind')
-const mcpRepo = process.env.MCP_REPO ?? join(repoRoot, 'kaleido-mcp')
 const out = join(srcTauri, 'resources', 'mind')
 
 // execFile (no shell) — args are passed as an array, so nothing is interpolated
 // into a command string. Safe by construction.
 const run = (cmd, args, cwd) => {
   console.log(`$ ${cmd} ${args.join(' ')}${cwd ? `   (in ${cwd})` : ''}`)
-  const env = { ...process.env }
-  // pnpm-only: the sibling repos pin an older packageManager (kaleido-mind →
-  // pnpm@9.0.0) and `deploy --legacy` only exists in pnpm ≥9.4. Disable pnpm's
-  // version switching so the host pnpm (which supports --legacy — the only
-  // deploy mode that yields a self-contained node_modules) runs regardless of
-  // each sibling's pin. Scoped to pnpm so npm doesn't warn on an unknown config.
-  if (cmd === 'pnpm') env.npm_config_manage_package_manager_versions = 'false'
-  execFileSync(cmd, args, { cwd, stdio: 'inherit', env })
+  execFileSync(cmd, args, { cwd, stdio: 'inherit' })
 }
 
 function reset() {
@@ -67,40 +57,24 @@ function reset() {
   writeFileSync(join(out, '.gitkeep'), '')
 }
 
-// 1. Provider — pnpm workspace member → `pnpm deploy --prod` gives a flat,
-//    prod-only tree (incl. the @kaleidorg/mind workspace dep + @qvac/sdk).
-function pruneProvider() {
-  if (!existsSync(mindRepo)) throw new Error(`kaleido-mind not found at ${mindRepo}`)
-  run('pnpm', ['--filter', '@kaleidorg/mind-provider', 'run', 'build'], mindRepo)
-  run(
-    'pnpm',
-    ['--filter', '@kaleidorg/mind-provider', 'deploy', '--prod', '--legacy', join(out, 'provider')],
-    mindRepo
+// Install npm `deps` into `<out>/<name>` as a self-contained, prod-only tree.
+// npm's default hoisted layout puts each dep's own files at
+// `<name>/node_modules/<pkg>/…`, which is what main.rs probes for.
+function installFromNpm(name, deps) {
+  const dir = join(out, name)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify(
+      { name: `kaleido-bundle-${name}`, version: '0.0.0', private: true, dependencies: deps },
+      null,
+      2
+    ) + '\n'
   )
+  run('npm', ['install', '--omit=dev', '--no-audit', '--no-fund'], dir)
 }
 
-// 2. MCP — standalone npm package → copy the built tree + a prod-only install.
-function pruneMcp() {
-  if (!existsSync(mcpRepo)) throw new Error(`kaleido-mcp not found at ${mcpRepo}`)
-  run('npm', ['run', 'build'], mcpRepo)
-  const dst = join(out, 'mcp')
-  mkdirSync(dst, { recursive: true })
-  for (const f of ['dist', 'package.json', 'package-lock.json']) {
-    cpSync(join(mcpRepo, f), join(dst, f), { recursive: true })
-  }
-  // Prefer a reproducible `npm ci`, but kaleido-mcp's committed lockfile can
-  // lag its package.json (e.g. a stale kaleido-sdk pin); fall back to
-  // `npm install` so sibling lockfile drift doesn't break the bundle.
-  const npmArgs = ['--omit=dev', '--ignore-scripts', '--no-audit', '--no-fund']
-  try {
-    run('npm', ['ci', ...npmArgs], dst)
-  } catch {
-    console.warn('  npm ci failed (lockfile drift?) — retrying with npm install')
-    run('npm', ['install', ...npmArgs], dst)
-  }
-}
-
-// 3. Node runtime for the target platform (host by default).
+// Node runtime for the target platform (host by default).
 function fetchNode() {
   const platMap = { darwin: 'darwin', linux: 'linux', win32: 'win' }
   const archMap = { x64: 'x64', arm64: 'arm64' }
@@ -128,10 +102,13 @@ function fetchNode() {
   console.log(`node ${NODE_VERSION} ${platform}/${arch} → ${binDst}`)
 }
 
-console.log(`Staging KaleidoMind bundle → ${out}`)
+console.log(`Staging KaleidoMind bundle (from npm) → ${out}`)
 reset()
-pruneProvider()
-pruneMcp()
+installFromNpm('provider', {
+  '@kaleidorg/mind-provider': PROVIDER_VERSION,
+  '@qvac/sdk': QVAC_VERSION,
+})
+installFromNpm('mcp', { 'kaleido-mcp': MCP_VERSION })
 fetchNode()
 console.log('\nDone. Verify size:  du -sh src-tauri/resources/mind')
 console.log('Then `tauri build` and confirm the agent runs in the packaged app.')

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -122,15 +122,27 @@ fn main() {
                 // varies by version/platform, so probe a few candidate roots.
                 if let Ok(res) = app.path().resource_dir() {
                     for base in [res.join("mind"), res.join("resources/mind"), res.clone()] {
-                        let provider = base.join("provider");
-                        if provider.join("dist/index.js").exists() {
-                            std::env::set_var("KALEIDO_MIND_PROVIDER_DIR", &provider);
-                            log::info!("[mind] bundled provider: {}", provider.display());
+                        // npm-install layout (provider installed from npm) first,
+                        // then the legacy pnpm-deploy layout.
+                        for provider in [
+                            base.join("provider/node_modules/@kaleidorg/mind-provider"),
+                            base.join("provider"),
+                        ] {
+                            if provider.join("dist/index.js").exists() {
+                                std::env::set_var("KALEIDO_MIND_PROVIDER_DIR", &provider);
+                                log::info!("[mind] bundled provider: {}", provider.display());
+                                break;
+                            }
                         }
-                        let mcp = base.join("mcp/dist/index.js");
-                        if mcp.exists() {
-                            std::env::set_var("KALEIDO_MCP_PATH", &mcp);
-                            log::info!("[mind] bundled mcp: {}", mcp.display());
+                        for mcp in [
+                            base.join("mcp/node_modules/kaleido-mcp/dist/index.js"),
+                            base.join("mcp/dist/index.js"),
+                        ] {
+                            if mcp.exists() {
+                                std::env::set_var("KALEIDO_MCP_PATH", &mcp);
+                                log::info!("[mind] bundled mcp: {}", mcp.display());
+                                break;
+                            }
                         }
                         for node in [base.join("node"), base.join("node.exe")] {
                             if node.exists() {


### PR DESCRIPTION
## Summary
Make the packaged KaleidoMind bundle install from **npm** instead of the local `../kaleido-mind` and `../kaleido-mcp` sibling repos — clean checkouts / CI / cloud builds had no siblings, so `pnpm bundle:mind` could only ever work on a fully-checked-out dev machine.

## Changes
- **`prepare-mind-bundle.mjs`** rewritten: `npm install` the published packages into `resources/mind/{provider,mcp}` — `@kaleidorg/mind-provider@^0.6.0` + `@qvac/sdk@^0.13.5` and `kaleido-mcp@^0.2.0`. No pnpm, no sibling repos. Versions overridable via `PROVIDER_VERSION` / `MCP_VERSION` / `QVAC_VERSION`.
- **`main.rs`** probe updated for npm's hoisted layout (`provider/node_modules/@kaleidorg/mind-provider/dist/index.js`, `mcp/node_modules/kaleido-mcp/dist/index.js`), with the legacy pnpm-deploy layout kept as a fallback.

Depends on `@kaleidorg/mind-provider@0.6.0` (now published to npm) and `kaleido-mcp@0.2.0`.

## Validation
`cargo check` clean. `node prepare-mind-bundle.mjs` stages a complete tree from npm (provider entry + mcp entry + Node runtime) with no sibling repos present.

> ⚠️ Still large (`@qvac/sdk` pulls every engine) — the LLM-only trim remains a separate follow-up. A model-load smoke test is recommended before the v0.5.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
