### PR TITLE
feat(mind): trim agent bundle to LLM-only + bundle it in release CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,20 @@ jobs:
         include:
           - platform: 'macos-latest'
             args: '--target aarch64-apple-darwin --bundles app,dmg'
+            mindPlatform: 'darwin'
+            mindArch: 'arm64'
           - platform: 'macos-latest'
             args: '--target x86_64-apple-darwin --bundles app,dmg'
+            mindPlatform: 'darwin'
+            mindArch: 'x64'
           - platform: 'ubuntu-22.04'
             args: ''
+            mindPlatform: 'linux'
+            mindArch: 'x64'
           - platform: 'windows-latest'
             args: ''
+            # KaleidoMind not bundled on Windows yet (no @qvac native build);
+            # leaving mindPlatform unset skips the bundle step below.
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -110,6 +118,16 @@ jobs:
 
       - name: Install frontend dependencies
         run: pnpm install
+
+      - name: Bundle KaleidoMind agent (from npm)
+        if: matrix.mindPlatform != ''
+        shell: bash
+        env:
+          TARGET_PLATFORM: ${{ matrix.mindPlatform }}
+          TARGET_ARCH: ${{ matrix.mindArch }}
+          NPM_OS: ${{ matrix.mindPlatform }}
+          NPM_CPU: ${{ matrix.mindArch }}
+        run: node src-tauri/scripts/prepare-mind-bundle.mjs
 
       - name: Build and sign rgb-lightning-node binary (Unix)
         if: matrix.platform != 'windows-latest'

--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -38,6 +38,31 @@ const PROVIDER_VERSION = process.env.PROVIDER_VERSION ?? '^0.6.0'
 const MCP_VERSION = process.env.MCP_VERSION ?? '^0.2.0'
 const QVAC_VERSION = process.env.QVAC_VERSION ?? '^0.13.5'
 
+// @qvac/sdk hard-depends on EVERY inference engine (~4 GB), but the desktop
+// text agent only uses the LLM (llamacpp completion) + embeddings. Drop the
+// engines it never loads. The SDK loads engines per-registered-plugin (not on
+// import), and the provider is written to tolerate missing STT/TTS plugins, so
+// removing these is safe for the chat path. Override with MIND_DROP_ENGINES=""
+// to keep everything, or a custom comma-separated list.
+const DROP_ENGINES = (
+  process.env.MIND_DROP_ENGINES ??
+  [
+    'translation-nmtcpp',
+    'vla-ggml',
+    'diffusion-cpp',
+    'transcription-whispercpp',
+    'tts-ggml',
+    'ocr-onnx',
+    'bci-whispercpp',
+    'transcription-parakeet',
+    'onnx',
+    'classification-ggml',
+  ].join(',')
+)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean)
+
 const here = dirname(fileURLToPath(import.meta.url))
 const srcTauri = resolve(here, '..')
 const out = join(srcTauri, 'resources', 'mind')
@@ -71,7 +96,27 @@ function installFromNpm(name, deps) {
       2
     ) + '\n'
   )
-  run('npm', ['install', '--omit=dev', '--no-audit', '--no-fund'], dir)
+  // NPM_OS / NPM_CPU force npm to fetch the TARGET platform's prebuilt native
+  // packages (e.g. the macOS runner is arm64 but also builds the x64 target).
+  const npmArgs = ['install', '--omit=dev', '--no-audit', '--no-fund']
+  if (process.env.NPM_OS) npmArgs.push(`--os=${process.env.NPM_OS}`)
+  if (process.env.NPM_CPU) npmArgs.push(`--cpu=${process.env.NPM_CPU}`)
+  run('npm', npmArgs, dir)
+}
+
+// Delete the unused @qvac inference engines from an installed tree (see
+// DROP_ENGINES). Removes ~3 GB the text agent never loads.
+function pruneEngines(name) {
+  if (!DROP_ENGINES.length) return
+  const qvac = join(out, name, 'node_modules', '@qvac')
+  if (!existsSync(qvac)) return
+  for (const eng of DROP_ENGINES) {
+    const p = join(qvac, eng)
+    if (existsSync(p)) {
+      rmSync(p, { recursive: true, force: true })
+      console.log(`  pruned @qvac/${eng}`)
+    }
+  }
 }
 
 // Node runtime for the target platform (host by default).
@@ -108,6 +153,7 @@ installFromNpm('provider', {
   '@kaleidorg/mind-provider': PROVIDER_VERSION,
   '@qvac/sdk': QVAC_VERSION,
 })
+pruneEngines('provider')
 installFromNpm('mcp', { 'kaleido-mcp': MCP_VERSION })
 fetchNode()
 console.log('\nDone. Verify size:  du -sh src-tauri/resources/mind')


### PR DESCRIPTION
## Summary
Two fixes so packaged binaries actually ship a working KaleidoMind, at a sane size.

**Trim (5.7 GB → 2.6 GB):** `prepare-mind-bundle.mjs` prunes the `@qvac` inference engines the text agent never loads (translation, diffusion, whisper, tts, ocr, vla, onnx, parakeet, bci, classification). Keeps `llm-llamacpp` + `embed-llamacpp` + `decoder-audio` + `sdk`. Configurable via `MIND_DROP_ENGINES`. Verified `import('@qvac/sdk')` still loads with the engines removed (SDK loads engines per-plugin, not on import; the provider tolerates missing STT/TTS).

**Wire into CI:** `build.yml` now runs the bundle step per matrix target before the Tauri build — previously it never ran, so release binaries shipped an empty `resources/mind` and the agent was dead. Cross-arch handled via `NPM_OS`/`NPM_CPU` (the macOS arm64 runner also builds x64). Skipped on Windows (no `@qvac` native build yet).

## Validation
Local: trimmed bundle stages to 2.6 GB; `import('@qvac/sdk')` OK post-prune. Full on-device model load to be confirmed via a `test-v0.5.0` pre-release build.

> Further trim possible later (e.g. drop `embed-llamacpp` if RAG unused, `bare-ffmpeg`) to approach ~1.7 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)