### PR TITLE
refactor(mind): no process-env mutation + on-demand CI fixes

### DIFF
--- a/.github/workflows/build-mind-assets.yml
+++ b/.github/workflows/build-mind-assets.yml
@@ -23,7 +23,10 @@ jobs:
           - runner: macos-latest
             platform: darwin
             arch: arm64
-          - runner: macos-13
+          # x64 cross-built on the arm64 mac runner — the bundle script's
+          # NPM_OS/NPM_CPU make npm fetch the darwin-x64 prebuilt natives, so we
+          # don't depend on the scarce macos-13 (Intel) runners.
+          - runner: macos-latest
             platform: darwin
             arch: x64
           - runner: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,7 @@ jobs:
           BUILD_AND_RUN_RGB_LIGHTNING_NODE: ${{ matrix.platform != 'windows-latest' && 'true' || 'false' }}
         id: tauri_build
         with:
-          tagName: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || (github.ref == 'refs/heads/test-build' && 'test-latest' || 'latest') }}
+          tagName: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || (github.ref == 'refs/heads/test-build' && 'test-latest' || 'latest') }}
           releaseName: ${{ startsWith(github.ref, 'refs/tags/v') && format('KaleidoSwap {0}', github.ref_name) || (github.ref == 'refs/heads/test-build' && 'Test App v__VERSION__' || 'App v__VERSION__') }}
           releaseBody: |
             ${{ startsWith(github.ref, 'refs/tags/v') && format('Release {0}', github.ref_name) || format('Release v{0}', env.VERSION) }}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -54,7 +54,7 @@ fn mind_stop(mind: State<Arc<MindProcess>>) -> Result<(), String> {
 /// prompts the on-demand download.
 #[tauri::command]
 fn mind_runtime_installed(app: AppHandle) -> bool {
-    mind_runtime::is_installed(&app) || mind::provider_available()
+    mind_runtime::is_installed(&app) || mind::provider_available(&app)
 }
 
 /// Download + install the agent runtime (provider/mcp/node) into app data.
@@ -126,16 +126,11 @@ fn main() {
                 // when the frontend detects the node is unlocked.
                 db::init();
 
-                // Production: the agent runtime (provider + MCP + Node) is no
-                // longer bundled in the installer — it's downloaded on demand
-                // into app data the first time the user enables KaleidoMind (see
-                // mind_runtime). If a previous download exists, point the sidecar
-                // env vars at it now so it's used without a restart. Dev runs the
-                // sidecar from the sibling repos (mind.rs fallback), so this is a
-                // safe no-op when nothing has been downloaded.
-                if mind_runtime::apply_env(app.handle()) {
-                    log::info!("[mind] using downloaded agent runtime");
-                }
+                // The agent runtime (provider + MCP + Node) isn't bundled in the
+                // installer — it's downloaded on demand into app data the first
+                // time the user enables KaleidoMind (see mind_runtime). mind.rs
+                // resolves it at sidecar-start time (downloaded → dev siblings),
+                // so nothing to wire up here.
 
                 // Set up system tray
                 tray::setup_tray(app.handle(), Arc::clone(&node_process))?;

--- a/src-tauri/src/mind.rs
+++ b/src-tauri/src/mind.rs
@@ -11,12 +11,15 @@
 //! sidecar runs the QVAC model, the P2P provider (for phone delegation), skills
 //! and MCP tools.
 //!
-//! Sidecar launch (dev-spawn, no bundling yet) is resolved in this order:
+//! Sidecar launch is resolved in this order:
 //!   1. `$KALEIDO_MIND_CMD` (+ optional `$KALEIDO_MIND_ARGS`, space-separated)
 //!   2. `node <dir>/dist/index.js`        if that build exists
 //!   3. `pnpm start` with cwd = `<dir>`    (runs `tsx src/index.ts`)
 //!
-//! where `<dir>` is `$KALEIDO_MIND_PROVIDER_DIR` or a sibling-path guess.
+//! where `<dir>` is `$KALEIDO_MIND_PROVIDER_DIR` (override), the on-demand
+//! runtime downloaded into app data (mind_runtime), or a dev sibling-path guess.
+//! Resolution happens at start time and is passed to the child via cmd.env —
+//! we never mutate this process's own environment.
 
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
@@ -58,7 +61,7 @@ impl MindProcess {
             return Ok(());
         }
 
-        let (program, args, cwd) = resolve_sidecar_command()?;
+        let (program, args, cwd) = resolve_sidecar_command(app)?;
         log::info!(
             "[mind] spawning sidecar: {} {} (cwd: {:?})",
             program,
@@ -94,7 +97,7 @@ impl MindProcess {
         // narrates tool calls ("I'll check your balance…") it can never execute.
         // The MCP server reads RLN_NODE_URL (default http://localhost:3001) +
         // KALEIDOSWAP_API_URL + WDK_SEED from the inherited env.
-        match resolve_mcp_path() {
+        match resolve_mcp_path(app) {
             Some(mcp) => {
                 log::info!("[mind] KALEIDO_MCP_PATH={}", mcp.display());
                 cmd.env("KALEIDO_MCP_PATH", mcp);
@@ -217,7 +220,9 @@ impl MindProcess {
 }
 
 /// Resolve `(program, args, cwd)` for launching the sidecar (see module docs).
-fn resolve_sidecar_command() -> Result<(String, Vec<String>, Option<PathBuf>), String> {
+fn resolve_sidecar_command(
+    app: &AppHandle,
+) -> Result<(String, Vec<String>, Option<PathBuf>), String> {
     // 1. Explicit command override.
     if let Ok(cmd) = std::env::var("KALEIDO_MIND_CMD") {
         let cmd = cmd.trim().to_string();
@@ -234,17 +239,20 @@ fn resolve_sidecar_command() -> Result<(String, Vec<String>, Option<PathBuf>), S
     }
 
     // 2/3. Resolve the provider directory, then prefer a built dist over pnpm.
-    let dir = resolve_provider_dir()
+    let dir = resolve_provider_dir(app)
         .ok_or("KaleidoMind provider dir not found — set KALEIDO_MIND_PROVIDER_DIR")?;
 
     let dist_entry = dir.join("dist").join("index.js");
     if dist_entry.exists() {
-        // Prefer a Node runtime BUNDLED with the app (KALEIDO_NODE_BIN, set from
-        // the resource dir in main.rs) so a packaged build doesn't depend on the
-        // user having Node installed; fall back to `node` on PATH for dev.
+        // Prefer the Node runtime shipped with a downloaded agent (or the
+        // KALEIDO_NODE_BIN override) so a packaged build doesn't need system
+        // Node; fall back to `node` on PATH for dev.
         let node = std::env::var("KALEIDO_NODE_BIN")
             .ok()
             .filter(|p| !p.trim().is_empty())
+            .or_else(|| {
+                crate::mind_runtime::node_bin_path(app).map(|p| p.to_string_lossy().into_owned())
+            })
             .unwrap_or_else(|| "node".to_string());
         return Ok((
             node,
@@ -258,21 +266,23 @@ fn resolve_sidecar_command() -> Result<(String, Vec<String>, Option<PathBuf>), S
 }
 
 /// Whether the sidecar can resolve a provider to run — true if a runtime has
-/// been downloaded (env set by mind_runtime::apply_env) OR the dev sibling repos
-/// are present. Used by the UI to decide whether the on-demand download is
-/// needed before showing KaleidoMind.
-pub fn provider_available() -> bool {
-    resolve_provider_dir().is_some()
+/// been downloaded OR the dev sibling repos are present. Used by the UI to
+/// decide whether the on-demand download is needed before showing KaleidoMind.
+pub fn provider_available(app: &AppHandle) -> bool {
+    resolve_provider_dir(app).is_some()
 }
 
-/// Find the apps/provider directory: env override, then sibling-path guesses
-/// relative to the current working directory (works under `tauri dev`).
-fn resolve_provider_dir() -> Option<PathBuf> {
+/// Find the provider dir: `KALEIDO_MIND_PROVIDER_DIR` override (read-only) → a
+/// downloaded runtime in app data → dev sibling repos relative to the cwd.
+fn resolve_provider_dir(app: &AppHandle) -> Option<PathBuf> {
     if let Ok(d) = std::env::var("KALEIDO_MIND_PROVIDER_DIR") {
         let p = PathBuf::from(d);
         if p.join("package.json").exists() {
             return Some(p);
         }
+    }
+    if let Some(p) = crate::mind_runtime::provider_dir(app) {
+        return Some(p);
     }
     let rel = ["apps", "provider"];
     let cwd = std::env::current_dir().ok()?;
@@ -293,16 +303,18 @@ fn resolve_provider_dir() -> Option<PathBuf> {
     None
 }
 
-/// Resolve the kaleido-mcp entry (`dist/index.js`) the sidecar connects as its
-/// tool source. `$KALEIDO_MCP_PATH` override first, then sibling-path guesses
-/// (`../kaleido-mcp/dist/index.js`) relative to the cwd — mirrors
-/// [`resolve_provider_dir`]. Returns `None` if no built MCP is found.
-fn resolve_mcp_path() -> Option<PathBuf> {
+/// Resolve the kaleido-mcp entry (`dist/index.js`) passed to the sidecar child:
+/// `$KALEIDO_MCP_PATH` override → a downloaded runtime → dev sibling guesses.
+/// Returns `None` if no built MCP is found.
+fn resolve_mcp_path(app: &AppHandle) -> Option<PathBuf> {
     if let Ok(p) = std::env::var("KALEIDO_MCP_PATH") {
         let pb = PathBuf::from(p.trim());
         if pb.exists() {
             return Some(pb);
         }
+    }
+    if let Some(p) = crate::mind_runtime::mcp_path(app) {
+        return Some(p);
     }
     let cwd = std::env::current_dir().ok()?;
     for base in [

--- a/src-tauri/src/mind_runtime.rs
+++ b/src-tauri/src/mind_runtime.rs
@@ -84,31 +84,34 @@ pub fn is_installed(app: &AppHandle) -> bool {
         .unwrap_or(false)
 }
 
-/// Point the sidecar env vars at the downloaded runtime if present. Called at
-/// startup (so a previously-downloaded runtime is used) and right after a
-/// successful install (so no app restart is needed). Returns true if found.
-pub fn apply_env(app: &AppHandle) -> bool {
-    let Some(base) = runtime_base(app) else {
-        return false;
-    };
-    let provider = provider_entry(&base);
+// Path resolvers for the downloaded runtime. mind.rs reads these at
+// sidecar-start time and passes them to the CHILD via cmd.env(...) — we never
+// mutate this process's own environment (std::env::set_var is not thread-safe).
+
+/// The downloaded provider package dir (`…/mind-provider`, parent of `dist/`),
+/// if a runtime has been installed.
+pub fn provider_dir(app: &AppHandle) -> Option<PathBuf> {
+    let provider = provider_entry(&runtime_base(app)?);
     if !provider.exists() {
-        return false;
+        return None;
     }
-    // KALEIDO_MIND_PROVIDER_DIR is the package dir (parent of dist/index.js).
-    if let Some(provider_dir) = provider.parent().and_then(Path::parent) {
-        std::env::set_var("KALEIDO_MIND_PROVIDER_DIR", provider_dir);
-        log::info!("[mind] runtime provider: {}", provider_dir.display());
-    }
-    let mcp = mcp_entry(&base);
-    if mcp.exists() {
-        std::env::set_var("KALEIDO_MCP_PATH", &mcp);
-    }
-    let node = node_bin(&base);
-    if node.exists() {
-        std::env::set_var("KALEIDO_NODE_BIN", &node);
-    }
-    true
+    // …/mind-provider/dist/index.js → …/mind-provider
+    provider
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+}
+
+/// The downloaded kaleido-mcp entry (`dist/index.js`), if installed.
+pub fn mcp_path(app: &AppHandle) -> Option<PathBuf> {
+    let p = mcp_entry(&runtime_base(app)?);
+    p.exists().then_some(p)
+}
+
+/// The downloaded bundled Node binary, if installed.
+pub fn node_bin_path(app: &AppHandle) -> Option<PathBuf> {
+    let p = node_bin(&runtime_base(app)?);
+    p.exists().then_some(p)
 }
 
 fn asset_name() -> Result<String, String> {
@@ -213,8 +216,9 @@ fn do_install(app: &AppHandle, name: &str, root: &Path) -> Result<(), String> {
         return Err("extracted tree missing provider entry".into());
     }
 
-    // 4. Wire env vars so the sidecar can start without an app restart.
-    apply_env(app);
+    // Done — no env mutation needed: mind.rs resolves this path on the next
+    // sidecar start (provider_dir/mcp_path/node_bin_path) and passes it to the
+    // child process, so the agent starts without an app restart.
     emit(app, "done", total, total, None);
     Ok(())
 }


### PR DESCRIPTION
Follow-up hardening on the on-demand agent download (#125).

## No process-env mutation (thread-safety)
The runtime resolver set `KALEIDO_MIND_PROVIDER_DIR`/`KALEIDO_MCP_PATH`/`KALEIDO_NODE_BIN` via `std::env::set_var` — including from the background download thread. POSIX `setenv` isn't thread-safe (races with any thread reading env → UB/crash), and Rust marks `set_var` `unsafe` in edition 2024. The paths aren't secrets, so it was a thread-safety bug, not a leak.

Fix: **never mutate our own env.** `mind.rs` resolves the paths at sidecar-start time — `KALEIDO_MIND_PROVIDER_DIR` override (read-only) → downloaded runtime in app data → dev siblings — and passes them to the **child** via `cmd.env(...)` (safe). The `KALEIDO_*` vars remain optional read-only overrides; only `KALEIDO_MCP_PATH` is forwarded to the child (the provider reads it to spawn the mcp).

## CI fixes
- `build.yml`: `test-v*` tags now get their **own** release instead of polluting the production `latest` draft (`refs/tags/` not just `/v`).
- `build-mind-assets.yml`: cross-build `darwin-x64` on `macos-latest` (via `NPM_OS`/`NPM_CPU`) so the asset set doesn't wait on scarce `macos-13` runners.

cargo check + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)