### PR TITLE
fix(mind): version-gated runtime upgrade + de-duped header + Experimental badge

### DIFF
--- a/src-tauri/src/mind_runtime.rs
+++ b/src-tauri/src/mind_runtime.rs
@@ -88,23 +88,33 @@ fn installed_version(app: &AppHandle) -> Option<String> {
     fs::read_to_string(vf).ok().map(|s| s.trim().to_string())
 }
 
-/// True once the CURRENT runtime version has been downloaded + extracted. A
-/// different (older) installed version reports false so the app re-downloads.
+/// The runtime base, but ONLY if the installed version matches ASSETS_TAG.
+/// A stale runtime (old/missing version marker) is treated as absent EVERYWHERE
+/// — so after a version bump the sidecar won't keep using an old, possibly
+/// broken runtime; the app shows the download screen and re-fetches the fix.
+fn current_runtime_base(app: &AppHandle) -> Option<PathBuf> {
+    if installed_version(app).as_deref() != Some(ASSETS_TAG) {
+        return None;
+    }
+    runtime_base(app)
+}
+
+/// True once the CURRENT runtime version has been downloaded + extracted.
 pub fn is_installed(app: &AppHandle) -> bool {
-    let Some(base) = runtime_base(app) else {
-        return false;
-    };
-    provider_entry(&base).exists() && installed_version(app).as_deref() == Some(ASSETS_TAG)
+    current_runtime_base(app)
+        .map(|b| provider_entry(&b).exists())
+        .unwrap_or(false)
 }
 
 // Path resolvers for the downloaded runtime. mind.rs reads these at
 // sidecar-start time and passes them to the CHILD via cmd.env(...) — we never
 // mutate this process's own environment (std::env::set_var is not thread-safe).
+// All gate on the current version so a stale runtime is ignored.
 
 /// The downloaded provider package dir (`…/mind-provider`, parent of `dist/`),
-/// if a runtime has been installed.
+/// if the current-version runtime is installed.
 pub fn provider_dir(app: &AppHandle) -> Option<PathBuf> {
-    let provider = provider_entry(&runtime_base(app)?);
+    let provider = provider_entry(&current_runtime_base(app)?);
     if !provider.exists() {
         return None;
     }
@@ -117,13 +127,13 @@ pub fn provider_dir(app: &AppHandle) -> Option<PathBuf> {
 
 /// The downloaded kaleido-mcp entry (`dist/index.js`), if installed.
 pub fn mcp_path(app: &AppHandle) -> Option<PathBuf> {
-    let p = mcp_entry(&runtime_base(app)?);
+    let p = mcp_entry(&current_runtime_base(app)?);
     p.exists().then_some(p)
 }
 
 /// The downloaded bundled Node binary, if installed.
 pub fn node_bin_path(app: &AppHandle) -> Option<PathBuf> {
-    let p = node_bin(&runtime_base(app)?);
+    let p = node_bin(&current_runtime_base(app)?);
     p.exists().then_some(p)
 }
 

--- a/src/routes/kaleido-mind/index.tsx
+++ b/src/routes/kaleido-mind/index.tsx
@@ -2,7 +2,7 @@
 // useMind() instance and renders the shared header + loading banner, with the
 // active sub-page (Brain / Pairing / Models / Skills / Chat) in the Outlet.
 
-import { Brain, Loader2 } from 'lucide-react'
+import { FlaskConical, Loader2 } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 
@@ -68,18 +68,13 @@ export const Component: React.FC = () => {
 
   return (
     <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-6 overflow-y-auto p-6">
-      {/* Header */}
+      {/* Header — the app's section header already shows the "KaleidoMind"
+          title, so here we just flag the feature as experimental + show status. */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Brain className="h-7 w-7 text-violet-400" />
-          <div>
-            <h1 className="text-xl font-bold text-white">KaleidoMind</h1>
-            <p className="text-sm text-gray-400">
-              Local AI brain — runs a model on this desktop and lets your phone
-              delegate to it.
-            </p>
-          </div>
-        </div>
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-300">
+          <FlaskConical className="h-3.5 w-3.5" />
+          Experimental
+        </span>
         <StatusPill
           model={status?.activeModelName}
           on={providerOn}


### PR DESCRIPTION
Follow-up to the slim-worker fix. The `version` marker gated only `is_installed`, but `provider_dir`/`mcp_path`/`node_bin_path` (→ `mind::provider_available`) resolved **any** existing provider regardless of version. So an app with the old v0.6.0 runtime kept using it after the `ASSETS_TAG` bump instead of re-downloading the fixed v0.6.1 — the model still aborted.

Now all resolvers + `is_installed` go through `current_runtime_base()`, which returns the runtime only when the installed `version` marker matches `ASSETS_TAG`. A stale runtime is treated as absent everywhere → download screen → clean re-fetch.

(Existing installs only needed this because v0.6.0's runtime had no marker; from v0.6.1 on, upgrades are automatic.) cargo check + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)