### PR TITLE
Bundle kaleido-mcp 0.2.1 + mind 0.6.2 (fix chat swap)

### DIFF
--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -35,7 +35,9 @@ import { tmpdir } from 'node:os'
 
 const NODE_VERSION = process.env.NODE_VERSION ?? '20.18.1' // pin; match CI
 const PROVIDER_VERSION = process.env.PROVIDER_VERSION ?? '^0.6.2'
-const MCP_VERSION = process.env.MCP_VERSION ?? '^0.2.0'
+// 0.2.1 fixes the chat-swap quote tool (optional layers + buy-side to_amount);
+// pairs with @kaleidorg/mind 0.6.2's corrected kaleidoswap-atomic recipe args.
+const MCP_VERSION = process.env.MCP_VERSION ?? '^0.2.1'
 const QVAC_VERSION = process.env.QVAC_VERSION ?? '^0.13.5'
 
 // @qvac/sdk hard-depends on EVERY inference engine (~4 GB), but the desktop


### PR DESCRIPTION
## Why

In chat, "can you buy 1 USDT on kaleidoswap?" fails immediately:

> MCP error -32602: Input validation error for tool kaleidoswap_get_quote: from_asset_id / to_asset_id / from_layer / to_layer / from_amount Required

Root cause is in the bundled packages — the `@kaleidorg/mind` `kaleidoswap-atomic` recipe drifted out of sync with kaleido-mcp's `kaleidoswap_get_quote` schema, and the tool didn't support a fixed-output ("buy") quote. Fixed in:

- kaleidoswap/kaleido-mcp#2 → publishes `kaleido-mcp@0.2.1`
- kaleidoswap/kaleido-mind#16 → publishes `@kaleidorg/mind@0.6.2`

## Change

Bumps `MCP_VERSION` `^0.2.0 → ^0.2.1` in `prepare-mind-bundle.mjs`. `PROVIDER_VERSION` stays `^0.6.2` — the provider depends on `@kaleidorg/mind@^0.6.1`, so a fresh install pulls the fixed `0.6.2` core transitively. The bundle is regenerated at build time, so this takes effect once both packages are published.

> ⚠️ Merge order: land + publish kaleido-mcp#2 and kaleido-mind#16 first, then merge this so the build's `prepare-mind-bundle` resolves the new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)