### PR TITLE
Add a stop button to the KaleidoMind chat

### DIFF
--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -34,7 +34,9 @@ import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
 
 const NODE_VERSION = process.env.NODE_VERSION ?? '20.18.1' // pin; match CI
-const PROVIDER_VERSION = process.env.PROVIDER_VERSION ?? '^0.6.2'
+// 0.6.3 adds the `cancel_chat` command (stop button); pulls @kaleidorg/mind
+// 0.6.4 which threads the AbortSignal through the funnel/recipe/qvac provider.
+const PROVIDER_VERSION = process.env.PROVIDER_VERSION ?? '^0.6.3'
 // 0.2.1 fixes the chat-swap quote tool (optional layers + buy-side to_amount);
 // pairs with @kaleidorg/mind 0.6.2's corrected kaleidoswap-atomic recipe args.
 const MCP_VERSION = process.env.MCP_VERSION ?? '^0.2.1'

--- a/src/api/mind.ts
+++ b/src/api/mind.ts
@@ -478,9 +478,17 @@ class MindClient {
   stopProvider() {
     return this.request<ProviderStatusEvent>({ cmd: 'stop' })
   }
-  chat(prompt: string, handlers?: ChatHandlers) {
+  /** Stop an in-flight chat turn (the stop button). Fire-and-forget — the
+   *  matching `chat()` promise then resolves with whatever was produced so far. */
+  cancelChat(chatId: string) {
+    return this.send({ chatId, cmd: 'cancel_chat' })
+  }
+  chat(
+    prompt: string,
+    handlers?: ChatHandlers,
+    chatId: string = crypto.randomUUID()
+  ) {
     // Generous: an agentic run may pause up to 120s on a tool confirmation.
-    const chatId = crypto.randomUUID()
     const off = this.on((event) => {
       if (event.type === 'chat_thinking_delta' && event.chatId === chatId) {
         handlers?.onThinking?.(event.delta)

--- a/src/hooks/useMind.ts
+++ b/src/hooks/useMind.ts
@@ -59,7 +59,13 @@ export interface UseMindResult {
   deleteSkill: (name: string) => Promise<void>
   addMcpServer: (name: string, url: string) => Promise<void>
   removeMcpServer: (id: string) => Promise<void>
-  chat: (prompt: string, handlers?: ChatHandlers) => Promise<ChatResult>
+  chat: (
+    prompt: string,
+    handlers?: ChatHandlers,
+    chatId?: string
+  ) => Promise<ChatResult>
+  /** Stop the in-flight chat turn (the stop button). */
+  cancelChat: (chatId: string) => Promise<void>
   /** Approve or decline the pending spend. */
   respondConfirm: (approved: boolean, reason?: string) => Promise<void>
 }
@@ -300,8 +306,15 @@ export function useMind(): UseMindResult {
     setCapabilities(await mindClient.removeMcpServer(id))
   }, [])
 
-  const chat = useCallback(async (prompt: string, handlers?: ChatHandlers) => {
-    return mindClient.chat(prompt, handlers)
+  const chat = useCallback(
+    async (prompt: string, handlers?: ChatHandlers, chatId?: string) => {
+      return mindClient.chat(prompt, handlers, chatId)
+    },
+    []
+  )
+
+  const cancelChat = useCallback(async (chatId: string) => {
+    await mindClient.cancelChat(chatId)
   }, [])
 
   const respondConfirm = useCallback(
@@ -320,6 +333,7 @@ export function useMind(): UseMindResult {
     addHuggingFaceModel,
     addMcpServer,
     addSkill,
+    cancelChat,
     cancelDownload,
     capabilities,
     catalog,

--- a/src/routes/kaleido-mind/chat.tsx
+++ b/src/routes/kaleido-mind/chat.tsx
@@ -13,6 +13,7 @@ import {
   Send,
   ShieldAlert,
   Sparkles,
+  Square,
   Trash2,
   Zap,
 } from 'lucide-react'
@@ -271,6 +272,13 @@ export const Component: React.FC = () => {
   const [sending, setSending] = useState(false)
   const [showHistory, setShowHistory] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
+  // chatId of the in-flight turn, so the stop button can cancel it.
+  const activeChatRef = useRef<string | null>(null)
+
+  const stop = () => {
+    const id = activeChatRef.current
+    if (id) void mind.cancelChat(id)
+  }
 
   const scrollToEnd = () =>
     setTimeout(
@@ -302,6 +310,7 @@ export const Component: React.FC = () => {
       },
     ])
     setSending(true)
+    activeChatRef.current = assistantId
     scrollToEnd()
     // Correlate tool calls↔results by (name, occurrence). The sidecar fires the
     // call event fire-and-forget after an async lookup, so a fast result can
@@ -330,63 +339,67 @@ export const Component: React.FC = () => {
       scrollToEnd()
     }
     try {
-      const reply = await mind.chat(prompt, {
-        onThinking: (delta) => {
-          setMessages((current) =>
-            current.map((message) =>
-              message.id === assistantId
-                ? {
-                    ...message,
-                    thinking: `${message.thinking ?? ''}${delta}`,
-                  }
-                : message
+      const reply = await mind.chat(
+        prompt,
+        {
+          onThinking: (delta) => {
+            setMessages((current) =>
+              current.map((message) =>
+                message.id === assistantId
+                  ? {
+                      ...message,
+                      thinking: `${message.thinking ?? ''}${delta}`,
+                    }
+                  : message
+              )
             )
-          )
-          scrollToEnd()
-        },
-        onToken: (delta) => {
-          setMessages((current) =>
-            current.map((message) =>
-              message.id === assistantId
-                ? { ...message, text: `${message.text}${delta}` }
-                : message
+            scrollToEnd()
+          },
+          onToken: (delta) => {
+            setMessages((current) =>
+              current.map((message) =>
+                message.id === assistantId
+                  ? { ...message, text: `${message.text}${delta}` }
+                  : message
+              )
             )
-          )
-          scrollToEnd()
+            scrollToEnd()
+          },
+          onToolCall: (call) => {
+            const n = (callSeq.get(call.name) ?? 0) + 1
+            callSeq.set(call.name, n)
+            const key = `${call.name}#${n}`
+            upsertToolEvent(
+              key,
+              { arguments: call.arguments },
+              {
+                arguments: call.arguments,
+                id: key,
+                name: call.name,
+                status: 'running',
+              }
+            )
+          },
+          onToolResult: (res) => {
+            const n = (resultSeq.get(res.name) ?? 0) + 1
+            resultSeq.set(res.name, n)
+            const key = `${res.name}#${n}`
+            const status: ChatToolEvent['status'] = res.ok ? 'done' : 'error'
+            upsertToolEvent(
+              key,
+              { result: res.result, status },
+              {
+                arguments: res.arguments,
+                id: key,
+                name: res.name,
+                result: res.result,
+                status,
+              }
+            )
+          },
         },
-        onToolCall: (call) => {
-          const n = (callSeq.get(call.name) ?? 0) + 1
-          callSeq.set(call.name, n)
-          const key = `${call.name}#${n}`
-          upsertToolEvent(
-            key,
-            { arguments: call.arguments },
-            {
-              arguments: call.arguments,
-              id: key,
-              name: call.name,
-              status: 'running',
-            }
-          )
-        },
-        onToolResult: (res) => {
-          const n = (resultSeq.get(res.name) ?? 0) + 1
-          resultSeq.set(res.name, n)
-          const key = `${res.name}#${n}`
-          const status: ChatToolEvent['status'] = res.ok ? 'done' : 'error'
-          upsertToolEvent(
-            key,
-            { result: res.result, status },
-            {
-              arguments: res.arguments,
-              id: key,
-              name: res.name,
-              result: res.result,
-              status,
-            }
-          )
-        },
-      })
+        assistantId
+      )
       setMessages((current) =>
         current.map((message) =>
           message.id === assistantId
@@ -421,6 +434,7 @@ export const Component: React.FC = () => {
       )
     } finally {
       setSending(false)
+      activeChatRef.current = null
       scrollToEnd()
     }
   }
@@ -710,7 +724,7 @@ export const Component: React.FC = () => {
               <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-primary [animation-delay:-0.15s]" />
               <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-primary" />
             </span>
-            KaleidoMind is responding… please wait
+            KaleidoMind is responding… tap ■ to stop
           </div>
         )}
         <div
@@ -735,14 +749,18 @@ export const Component: React.FC = () => {
             value={input}
           />
           <button
-            aria-label={sending ? 'KaleidoMind is responding' : 'Send message'}
-            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-primary text-surface-base transition-all hover:bg-primary-emphasis active:scale-95 disabled:opacity-40"
-            disabled={!providerOn || sending || !input.trim()}
-            onClick={() => send()}
+            aria-label={sending ? 'Stop KaleidoMind' : 'Send message'}
+            className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg transition-all active:scale-95 disabled:opacity-40 ${
+              sending
+                ? 'bg-red text-white hover:bg-red/90'
+                : 'bg-primary text-surface-base hover:bg-primary-emphasis'
+            }`}
+            disabled={!providerOn || (!sending && !input.trim())}
+            onClick={() => (sending ? stop() : send())}
             type="button"
           >
             {sending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <Square className="h-3.5 w-3.5 fill-current" />
             ) : (
               <Send className="h-4 w-4" />
             )}


### PR DESCRIPTION
## Why

Users asked to be able to **stop KaleidoMind while it's responding** — to kill a runaway on-device generation, or abort a chat heading the wrong way (e.g. a swap they didn't mean to start).

## What

While a turn is in flight, the send button becomes a red **stop** button. Clicking it cancels the running inference; the `chat()` promise then resolves with whatever was produced so far and the turn ends cleanly.

- `mind.ts`: `chat()` accepts a caller-supplied `chatId`; new `cancelChat(chatId)` → sidecar `cancel_chat`.
- `useMind.ts`: expose `cancelChat`, thread `chatId` through `chat()`.
- `chat.tsx`: track the in-flight `chatId` in a ref; Send↔Stop toggle; "tap ■ to stop" hint while responding.
- `prepare-mind-bundle.mjs`: `PROVIDER_VERSION ^0.6.2 → ^0.6.3`.

## Depends on (published)

- `@kaleidorg/mind-provider@0.6.3` — new `cancel_chat` command.
- `@kaleidorg/mind@0.6.4` — threads the `AbortSignal` through the funnel / recipe / qvac provider so the abort actually cancels the model run (kaleidoswap/kaleido-mind#18).

The bundle regenerates at build time, so this takes effect on the next desktop build. 1087 frontend tests + type-check + lint green.

> Reminder: do a clean re-bundle (`rm -rf src-tauri/resources/mind && pnpm bundle:mind`) so npm re-resolves provider `0.6.3` + core `0.6.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)