### PR TITLE
Release 0.5.0 — KaleidoMind on-device AI agent (QVAC hackathon)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## [Version 0.5.0] - 2026-06-21
 
+> ⚠️ **KaleidoMind is experimental.** The on-device agent and chat-based trading are an early preview — expect rough edges, occasional incorrect responses, and changing behavior between releases. Always review the confirmation details before approving any spend.
+
 ### 🚀 Features
-- **KaleidoMind — on-device AI agent**: A local, private assistant that runs entirely on-device via the QVAC engine. Chat with your wallet and node in natural language — no data leaves the machine. Bundled with the app and downloaded on first enable (provider + MCP runtime, `mind-assets-v0.7.0`)
+- **KaleidoMind — on-device AI agent (experimental)**: A local, private assistant that runs entirely on-device via the QVAC engine. Chat with your wallet and node in natural language — no data leaves the machine. Bundled with the app and downloaded on first enable (provider + MCP runtime, `mind-assets-v0.7.0`)
 - **Trade by chat**: Ask "buy 1 USDT on KaleidoSwap" and the agent quotes the maker and runs the full atomic swap (quote → init → whitelist → execute) behind a single confirmation gate showing the real numbers
 - **Buy a Lightning channel by chat**: Order inbound BTC liquidity or a new RGB asset channel (USDT/XAUT) pre-loaded via the LSP, as a one-confirmation flow
 - **Agent tab (autonomy)**: Schedule the agent to run optimizer tasks (portfolio, DCA-style) with risk limits and a dry-run default; review recent runs and costs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [Version 0.5.0] - 2026-06-21
+
+### 🚀 Features
+- **KaleidoMind — on-device AI agent**: A local, private assistant that runs entirely on-device via the QVAC engine. Chat with your wallet and node in natural language — no data leaves the machine. Bundled with the app and downloaded on first enable (provider + MCP runtime, `mind-assets-v0.7.0`)
+- **Trade by chat**: Ask "buy 1 USDT on KaleidoSwap" and the agent quotes the maker and runs the full atomic swap (quote → init → whitelist → execute) behind a single confirmation gate showing the real numbers
+- **Buy a Lightning channel by chat**: Order inbound BTC liquidity or a new RGB asset channel (USDT/XAUT) pre-loaded via the LSP, as a one-confirmation flow
+- **Agent tab (autonomy)**: Schedule the agent to run optimizer tasks (portfolio, DCA-style) with risk limits and a dry-run default; review recent runs and costs
+- **Stop button**: Cancel an in-flight chat turn at any time — the running on-device inference is aborted immediately and the turn ends cleanly
+- **Live tool activity + reasoning**: Watch the model's tool calls (balances, channels, quotes) render as typed result cards, and optionally expand its `<think>` reasoning
+- **Wallet & node tools over MCP**: The agent reads balances, channels, and quotes, and drafts payments/swaps through the KaleidoSwap MCP server, with every spend gated by explicit confirmation
+
+### 🔧 Improvements
+- **Redesigned buy-channel flow**: Cleaner channel summary and payment-review UI with richer states and clearer cost breakdowns
+- **Mind runtime v0.7.0**: Updated the bundled provider (`@kaleidorg/mind-provider ^0.6.3`) and MCP (`kaleido-mcp ^0.2.1`) so chat trading and the stop button work end to end
+- **SDK migration**: Moved to `kaleido-sdk ^0.1.11` (BitcoinNetwork node/api split, TransferKind enum, refresh defaults)
+
+### 🐛 Bug Fixes
+- **Chat swap quote failed validation**: "buy 1 USDT" hit an MCP input-validation error because the swap recipe sent the wrong argument names; the quote tool now derives layers and accepts a buy-side amount, and the recipe emits the correct fields
+- **Chat stalled on extraction cancel/timeout**: A cancelled or timed-out slot-extraction inference on small models no longer fails the whole request — it degrades to deterministic parsing for requests the app already understands
+
 ## [Version 0.4.0] - 2026-04-15
 
 ### 🚀 Features

--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -34,7 +34,9 @@ import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
 
 const NODE_VERSION = process.env.NODE_VERSION ?? '20.18.1' // pin; match CI
-const PROVIDER_VERSION = process.env.PROVIDER_VERSION ?? '^0.6.2'
+// 0.6.3 adds the `cancel_chat` command (stop button); pulls @kaleidorg/mind
+// 0.6.4 which threads the AbortSignal through the funnel/recipe/qvac provider.
+const PROVIDER_VERSION = process.env.PROVIDER_VERSION ?? '^0.6.3'
 // 0.2.1 fixes the chat-swap quote tool (optional layers + buy-side to_amount);
 // pairs with @kaleidorg/mind 0.6.2's corrected kaleidoswap-atomic recipe args.
 const MCP_VERSION = process.env.MCP_VERSION ?? '^0.2.1'

--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -35,7 +35,9 @@ import { tmpdir } from 'node:os'
 
 const NODE_VERSION = process.env.NODE_VERSION ?? '20.18.1' // pin; match CI
 const PROVIDER_VERSION = process.env.PROVIDER_VERSION ?? '^0.6.2'
-const MCP_VERSION = process.env.MCP_VERSION ?? '^0.2.0'
+// 0.2.1 fixes the chat-swap quote tool (optional layers + buy-side to_amount);
+// pairs with @kaleidorg/mind 0.6.2's corrected kaleidoswap-atomic recipe args.
+const MCP_VERSION = process.env.MCP_VERSION ?? '^0.2.1'
 const QVAC_VERSION = process.env.QVAC_VERSION ?? '^0.13.5'
 
 // @qvac/sdk hard-depends on EVERY inference engine (~4 GB), but the desktop

--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -34,7 +34,7 @@ import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
 
 const NODE_VERSION = process.env.NODE_VERSION ?? '20.18.1' // pin; match CI
-const PROVIDER_VERSION = process.env.PROVIDER_VERSION ?? '^0.6.0'
+const PROVIDER_VERSION = process.env.PROVIDER_VERSION ?? '^0.6.2'
 const MCP_VERSION = process.env.MCP_VERSION ?? '^0.2.0'
 const QVAC_VERSION = process.env.QVAC_VERSION ?? '^0.13.5'
 

--- a/src-tauri/src/mind_runtime.rs
+++ b/src-tauri/src/mind_runtime.rs
@@ -17,7 +17,7 @@ use tauri::{AppHandle, Emitter, Manager};
 
 /// GitHub release tag the agent tarballs live under. Bump when the agent
 /// (provider/mcp/@qvac) version changes and new assets are published.
-const ASSETS_TAG: &str = "mind-assets-v0.6.1";
+const ASSETS_TAG: &str = "mind-assets-v0.7.0";
 const ASSETS_REPO: &str = "kaleidoswap/desktop-app";
 const RUNTIME_EVENT: &str = "mind-runtime";
 

--- a/src/api/mind.ts
+++ b/src/api/mind.ts
@@ -478,9 +478,17 @@ class MindClient {
   stopProvider() {
     return this.request<ProviderStatusEvent>({ cmd: 'stop' })
   }
-  chat(prompt: string, handlers?: ChatHandlers) {
+  /** Stop an in-flight chat turn (the stop button). Fire-and-forget — the
+   *  matching `chat()` promise then resolves with whatever was produced so far. */
+  cancelChat(chatId: string) {
+    return this.send({ chatId, cmd: 'cancel_chat' })
+  }
+  chat(
+    prompt: string,
+    handlers?: ChatHandlers,
+    chatId: string = crypto.randomUUID()
+  ) {
     // Generous: an agentic run may pause up to 120s on a tool confirmation.
-    const chatId = crypto.randomUUID()
     const off = this.on((event) => {
       if (event.type === 'chat_thinking_delta' && event.chatId === chatId) {
         handlers?.onThinking?.(event.delta)

--- a/src/components/BuyChannelModal/components/PaymentSection.tsx
+++ b/src/components/BuyChannelModal/components/PaymentSection.tsx
@@ -147,8 +147,8 @@ export const PaymentSection: React.FC<PaymentSectionProps> = ({
               </div>
             </div>
 
-            <div className="mt-4 rounded-[20px] border border-border-subtle bg-white/5 p-3">
-              <div className="mx-auto w-full max-w-[200px] rounded-[16px] bg-white p-3 shadow-lg">
+            <div className="mt-4 flex flex-1 items-center justify-center">
+              <div className="w-full max-w-[200px] rounded-2xl bg-white p-3 shadow-lg">
                 <QRCodeSVG
                   size={256}
                   style={{ display: 'block', height: 'auto', width: '100%' }}

--- a/src/components/OrderSummaryCard.tsx
+++ b/src/components/OrderSummaryCard.tsx
@@ -56,50 +56,52 @@ const LiquiditySummaryCard = ({
   outbound,
   outboundColor,
   outboundLabel,
+  showTotal = true,
   subtitle,
   ticker,
   title,
   titleClassName,
   totalLabel,
-}: LiquiditySection) => (
+}: LiquiditySection & { showTotal?: boolean }) => (
   <div
-    className={`min-w-0 rounded-[22px] border p-4 shadow-[0_12px_30px_-22px_rgba(0,0,0,0.7)] ${borderClassName} ${backgroundClassName}`}
+    className={`min-w-0 rounded-2xl border p-4 ${borderClassName} ${backgroundClassName}`}
   >
-    <div className="flex flex-wrap items-start gap-3">
-      <div className="min-w-0 flex flex-1 items-start gap-3">
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex min-w-0 items-center gap-2.5">
         <img
           alt={iconAlt}
-          className="mt-0.5 h-5 w-5 flex-shrink-0 rounded-full"
+          className="h-5 w-5 flex-shrink-0 rounded-full"
           src={iconSrc}
         />
-        <div className="min-w-0">
-          <p
-            className={`text-sm font-semibold ${
-              titleClassName || 'text-content-primary'
-            }`}
-          >
-            {title}
+        <p
+          className={`truncate text-sm font-semibold ${
+            titleClassName || 'text-content-primary'
+          }`}
+        >
+          {title}
+        </p>
+      </div>
+      {showTotal && (
+        <div className="shrink-0 text-right">
+          <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-content-tertiary">
+            {ticker}
           </p>
-          {subtitle && (
-            <p className="mt-1 text-xs leading-relaxed text-content-secondary">
-              {subtitle}
-            </p>
-          )}
+          <p className={`${accentClassName} text-sm font-semibold`}>
+            {totalLabel}
+          </p>
         </div>
-      </div>
-      <div className="rounded-xl border border-border-subtle bg-surface-overlay/60 px-3 py-2 text-right">
-        <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-content-tertiary">
-          {ticker}
-        </p>
-        <p className={`${accentClassName} mt-1 text-sm font-semibold`}>
-          {totalLabel}
-        </p>
-      </div>
+      )}
     </div>
 
-    {meta && <div className="mt-4">{meta}</div>}
+    {subtitle && (
+      <p className="mt-2 text-xs leading-relaxed text-content-secondary">
+        {subtitle}
+      </p>
+    )}
 
-    <div className="mt-4">
+    {meta && <div className="mt-3">{meta}</div>}
+
+    <div className="mt-3">
       <LiquidityBar
         inbound={inbound}
         inboundColor={inboundColor}
@@ -123,7 +125,7 @@ export const OrderSummaryCard = ({
   totalCapacityValue,
 }: OrderSummaryCardProps) => {
   return (
-    <div className="overflow-hidden rounded-[24px] border border-border-subtle bg-surface-base/80 shadow-[0_18px_60px_rgba(2,6,23,0.35)]">
+    <div className="overflow-hidden rounded-[24px] border border-border-subtle bg-surface-base/80 shadow-[0_12px_40px_rgba(2,6,23,0.25)]">
       {(title || totalCapacityValue) && (
         <div className="border-b border-border-subtle bg-gradient-to-br from-amber-400/10 via-transparent to-cyan-400/6 p-5">
           <div className="flex items-start justify-between gap-4">
@@ -169,12 +171,16 @@ export const OrderSummaryCard = ({
           }`}
         >
           {liquiditySections.map((section) => (
-            <LiquiditySummaryCard key={section.title} {...section} />
+            <LiquiditySummaryCard
+              key={section.title}
+              showTotal={liquiditySections.length > 1}
+              {...section}
+            />
           ))}
         </div>
 
         {costBreakdown && (
-          <div className="rounded-[22px] border border-border-subtle bg-surface-overlay/40 p-4">
+          <div className="rounded-2xl border border-border-subtle/70 bg-surface-overlay/30 p-4">
             <div className="space-y-1.5">
               {costBreakdown.items.map((item) => (
                 <div

--- a/src/hooks/useMind.ts
+++ b/src/hooks/useMind.ts
@@ -59,7 +59,13 @@ export interface UseMindResult {
   deleteSkill: (name: string) => Promise<void>
   addMcpServer: (name: string, url: string) => Promise<void>
   removeMcpServer: (id: string) => Promise<void>
-  chat: (prompt: string, handlers?: ChatHandlers) => Promise<ChatResult>
+  chat: (
+    prompt: string,
+    handlers?: ChatHandlers,
+    chatId?: string
+  ) => Promise<ChatResult>
+  /** Stop the in-flight chat turn (the stop button). */
+  cancelChat: (chatId: string) => Promise<void>
   /** Approve or decline the pending spend. */
   respondConfirm: (approved: boolean, reason?: string) => Promise<void>
 }
@@ -300,8 +306,15 @@ export function useMind(): UseMindResult {
     setCapabilities(await mindClient.removeMcpServer(id))
   }, [])
 
-  const chat = useCallback(async (prompt: string, handlers?: ChatHandlers) => {
-    return mindClient.chat(prompt, handlers)
+  const chat = useCallback(
+    async (prompt: string, handlers?: ChatHandlers, chatId?: string) => {
+      return mindClient.chat(prompt, handlers, chatId)
+    },
+    []
+  )
+
+  const cancelChat = useCallback(async (chatId: string) => {
+    await mindClient.cancelChat(chatId)
   }, [])
 
   const respondConfirm = useCallback(
@@ -320,6 +333,7 @@ export function useMind(): UseMindResult {
     addHuggingFaceModel,
     addMcpServer,
     addSkill,
+    cancelChat,
     cancelDownload,
     capabilities,
     catalog,

--- a/src/routes/kaleido-mind/chat.tsx
+++ b/src/routes/kaleido-mind/chat.tsx
@@ -13,6 +13,7 @@ import {
   Send,
   ShieldAlert,
   Sparkles,
+  Square,
   Trash2,
   Zap,
 } from 'lucide-react'
@@ -271,6 +272,13 @@ export const Component: React.FC = () => {
   const [sending, setSending] = useState(false)
   const [showHistory, setShowHistory] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
+  // chatId of the in-flight turn, so the stop button can cancel it.
+  const activeChatRef = useRef<string | null>(null)
+
+  const stop = () => {
+    const id = activeChatRef.current
+    if (id) void mind.cancelChat(id)
+  }
 
   const scrollToEnd = () =>
     setTimeout(
@@ -302,6 +310,7 @@ export const Component: React.FC = () => {
       },
     ])
     setSending(true)
+    activeChatRef.current = assistantId
     scrollToEnd()
     // Correlate tool calls↔results by (name, occurrence). The sidecar fires the
     // call event fire-and-forget after an async lookup, so a fast result can
@@ -330,63 +339,67 @@ export const Component: React.FC = () => {
       scrollToEnd()
     }
     try {
-      const reply = await mind.chat(prompt, {
-        onThinking: (delta) => {
-          setMessages((current) =>
-            current.map((message) =>
-              message.id === assistantId
-                ? {
-                    ...message,
-                    thinking: `${message.thinking ?? ''}${delta}`,
-                  }
-                : message
+      const reply = await mind.chat(
+        prompt,
+        {
+          onThinking: (delta) => {
+            setMessages((current) =>
+              current.map((message) =>
+                message.id === assistantId
+                  ? {
+                      ...message,
+                      thinking: `${message.thinking ?? ''}${delta}`,
+                    }
+                  : message
+              )
             )
-          )
-          scrollToEnd()
-        },
-        onToken: (delta) => {
-          setMessages((current) =>
-            current.map((message) =>
-              message.id === assistantId
-                ? { ...message, text: `${message.text}${delta}` }
-                : message
+            scrollToEnd()
+          },
+          onToken: (delta) => {
+            setMessages((current) =>
+              current.map((message) =>
+                message.id === assistantId
+                  ? { ...message, text: `${message.text}${delta}` }
+                  : message
+              )
             )
-          )
-          scrollToEnd()
+            scrollToEnd()
+          },
+          onToolCall: (call) => {
+            const n = (callSeq.get(call.name) ?? 0) + 1
+            callSeq.set(call.name, n)
+            const key = `${call.name}#${n}`
+            upsertToolEvent(
+              key,
+              { arguments: call.arguments },
+              {
+                arguments: call.arguments,
+                id: key,
+                name: call.name,
+                status: 'running',
+              }
+            )
+          },
+          onToolResult: (res) => {
+            const n = (resultSeq.get(res.name) ?? 0) + 1
+            resultSeq.set(res.name, n)
+            const key = `${res.name}#${n}`
+            const status: ChatToolEvent['status'] = res.ok ? 'done' : 'error'
+            upsertToolEvent(
+              key,
+              { result: res.result, status },
+              {
+                arguments: res.arguments,
+                id: key,
+                name: res.name,
+                result: res.result,
+                status,
+              }
+            )
+          },
         },
-        onToolCall: (call) => {
-          const n = (callSeq.get(call.name) ?? 0) + 1
-          callSeq.set(call.name, n)
-          const key = `${call.name}#${n}`
-          upsertToolEvent(
-            key,
-            { arguments: call.arguments },
-            {
-              arguments: call.arguments,
-              id: key,
-              name: call.name,
-              status: 'running',
-            }
-          )
-        },
-        onToolResult: (res) => {
-          const n = (resultSeq.get(res.name) ?? 0) + 1
-          resultSeq.set(res.name, n)
-          const key = `${res.name}#${n}`
-          const status: ChatToolEvent['status'] = res.ok ? 'done' : 'error'
-          upsertToolEvent(
-            key,
-            { result: res.result, status },
-            {
-              arguments: res.arguments,
-              id: key,
-              name: res.name,
-              result: res.result,
-              status,
-            }
-          )
-        },
-      })
+        assistantId
+      )
       setMessages((current) =>
         current.map((message) =>
           message.id === assistantId
@@ -421,6 +434,7 @@ export const Component: React.FC = () => {
       )
     } finally {
       setSending(false)
+      activeChatRef.current = null
       scrollToEnd()
     }
   }
@@ -710,7 +724,7 @@ export const Component: React.FC = () => {
               <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-primary [animation-delay:-0.15s]" />
               <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-primary" />
             </span>
-            KaleidoMind is responding… please wait
+            KaleidoMind is responding… tap ■ to stop
           </div>
         )}
         <div
@@ -735,14 +749,18 @@ export const Component: React.FC = () => {
             value={input}
           />
           <button
-            aria-label={sending ? 'KaleidoMind is responding' : 'Send message'}
-            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-primary text-surface-base transition-all hover:bg-primary-emphasis active:scale-95 disabled:opacity-40"
-            disabled={!providerOn || sending || !input.trim()}
-            onClick={() => send()}
+            aria-label={sending ? 'Stop KaleidoMind' : 'Send message'}
+            className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg transition-all active:scale-95 disabled:opacity-40 ${
+              sending
+                ? 'bg-red text-white hover:bg-red/90'
+                : 'bg-primary text-surface-base hover:bg-primary-emphasis'
+            }`}
+            disabled={!providerOn || (!sending && !input.trim())}
+            onClick={() => (sending ? stop() : send())}
             type="button"
           >
             {sending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <Square className="h-3.5 w-3.5 fill-current" />
             ) : (
               <Send className="h-4 w-4" />
             )}

--- a/src/routes/order-new-channel/components/OrderSummary.tsx
+++ b/src/routes/order-new-channel/components/OrderSummary.tsx
@@ -47,7 +47,7 @@ export const OrderSummary: React.FC<OrderSummaryProps> = ({
       inboundLabel: `${formatBitcoinAmount(order.lsp_balance_sat, bitcoinUnit)} ${bitcoinUnit}`,
       outbound: order.client_balance_sat,
       outboundLabel: `${formatBitcoinAmount(order.client_balance_sat, bitcoinUnit)} ${bitcoinUnit}`,
-      ticker: t('orderChannel.step3.confirmedChannel'),
+      ticker: t('orderChannel.step3.total'),
       title: t('orderChannel.step3.confirmedChannel'),
       totalLabel: `${formatBitcoinAmount(totalCapacity, bitcoinUnit)} ${bitcoinUnit}`,
     }),


### PR DESCRIPTION
## Release 0.5.0 — KaleidoMind

Promotes `dev` to `main` for the QVAC hackathon submission. Headline: **KaleidoMind**, an on-device AI agent that runs entirely locally via the QVAC engine — chat with your wallet and node, trade by chat, and buy Lightning channels, with every spend gated by explicit confirmation.

### Highlights
- 🤖 **KaleidoMind agent** — private, on-device chat (provider + MCP runtime `mind-assets-v0.7.0`)
- 💱 **Trade by chat** — "buy 1 USDT" runs the full atomic swap behind one confirmation
- ⚡ **Buy a channel by chat** — inbound BTC liquidity or a pre-loaded RGB asset channel via the LSP
- 🧠 **Agent (autonomy) tab** — scheduled optimizer tasks with risk limits and a dry-run default
- ⏹️ **Stop button** — cancel an in-flight turn; the on-device inference aborts immediately
- 🐛 Fixes for the chat-swap quote validation and extraction cancel/timeout handling

Full notes in [CHANGELOG.md](CHANGELOG.md).

### Commits (dev → main)
- `docs(changelog)` 0.5.0 release notes
- Add a stop button to the KaleidoMind chat (#131)
- Bundle kaleido-mcp 0.2.1 — chat-swap quote fix (#130)
- Clean up buy-channel summary + payment review UI
- Pin mind-provider ^0.6.2 for the v0.7.0 runtime build
- Bump runtime to mind-assets-v0.7.0

### Depends on (published to npm)
`@kaleidorg/mind@0.6.4`, `@kaleidorg/mind-provider@0.6.3`, `kaleido-mcp@0.2.1` — pulled into the bundle at build time by `prepare-mind-bundle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)