### PR TITLE
feat(settings): implement Change Password (node lock→changepassword→unlock)

### DIFF
--- a/src/api/node-api-wrapper.ts
+++ b/src/api/node-api-wrapper.ts
@@ -50,6 +50,7 @@ import type {
   SignMessageRequest,
   SignMessageResponse,
   UnlockRequest,
+  ChangePasswordRequest,
   KeysendRequest,
   KeysendResponse,
   ListPeersResponse,
@@ -111,6 +112,14 @@ export class NodeApiWrapper {
 
   async lockWallet(): Promise<ApiResult<void>> {
     return this.execute(() => this.client.lockWallet())
+  }
+
+  // Node re-encrypts the mnemonic with the new password. NB: the node requires
+  // the wallet to be LOCKED for this call (it returns 403 otherwise).
+  async changePassword(
+    request: ChangePasswordRequest
+  ): Promise<ApiResult<void>> {
+    return this.execute(() => this.client.changePassword(request))
   }
 
   async backup(request: BackupRequest): Promise<ApiResult<void>> {

--- a/src/components/ChangePasswordModal/index.tsx
+++ b/src/components/ChangePasswordModal/index.tsx
@@ -1,26 +1,42 @@
-import { useState } from 'react'
+import { invoke } from '@tauri-apps/api/core'
 import {
   KeyRound,
   X,
   Eye,
   EyeOff,
   CheckCircle2,
-  Save,
   AlertTriangle,
+  Loader2,
+  Lock,
 } from 'lucide-react'
+import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
-import { invoke } from '@tauri-apps/api/core'
+import { useNavigate } from 'react-router-dom'
 
+import { WALLET_UNLOCK_PATH } from '../../app/router/paths'
 import {
   getModalPortalTarget,
   getModalPositionClass,
 } from '../../helpers/modalPortal'
+import { nodeApi } from '../../slices/nodeApi/nodeApi.slice'
 
 interface ChangePasswordModalProps {
   showModal: boolean
   accountName: string
   onClose: () => void
+}
+
+// Outcome of the change flow — determines the final screen. In both terminal
+// states the node has been LOCKED (the node's /changepassword requires it), so
+// the user must re-unlock; we send them to the standard unlock screen.
+type Phase = 'form' | 'changed' | 'locked-unchanged'
+
+const messageOf = (err: unknown, fallback: string): string => {
+  const data = (err as { data?: { error?: string } } | undefined)?.data
+  if (data?.error) return data.error
+  if (err instanceof Error) return err.message
+  return fallback
 }
 
 export const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
@@ -29,30 +45,45 @@ export const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
   onClose,
 }) => {
   const { t } = useTranslation()
+  const navigate = useNavigate()
+
+  const [lock] = nodeApi.endpoints.lock.useMutation()
+  const [changePassword] = nodeApi.useChangePasswordMutation()
+
   const [currentPassword, setCurrentPassword] = useState('')
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
-  const [seedPhrase, setSeedPhrase] = useState('')
   const [showCurrent, setShowCurrent] = useState(false)
   const [showNew, setShowNew] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [progress, setProgress] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState(false)
-  // true when the account has no encrypted mnemonic stored in the DB
-  const [needsSeedPhrase, setNeedsSeedPhrase] = useState(false)
+  const [phase, setPhase] = useState<Phase>('form')
 
   if (!showModal) return null
 
-  const handleClose = () => {
+  const reset = () => {
     setCurrentPassword('')
     setNewPassword('')
     setConfirmPassword('')
-    setSeedPhrase('')
     setError(null)
-    setSuccess(false)
-    setNeedsSeedPhrase(false)
+    setProgress(null)
+    setPhase('form')
+    setIsLoading(false)
+  }
+
+  const handleClose = () => {
+    reset()
     onClose()
+  }
+
+  // Once the node is locked there is no way back to a working session from
+  // here — the only safe exit is the unlock screen.
+  const goToUnlock = () => {
+    reset()
+    onClose()
+    navigate(WALLET_UNLOCK_PATH)
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -84,37 +115,17 @@ export const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
 
     setIsLoading(true)
 
-    let mnemonic: string
-
-    if (needsSeedPhrase) {
-      // User provided seed phrase manually — validate basic word count
-      const words = seedPhrase.trim().split(/\s+/)
-      if (words.length !== 12 && words.length !== 24) {
-        setError(
-          t(
-            'changePassword.errorInvalidSeed',
-            'Please enter a valid 12 or 24-word recovery phrase.'
-          )
-        )
-        setIsLoading(false)
-        return
-      }
-      mnemonic = words.join(' ')
-    } else {
-      // Try to decrypt from DB
-      try {
-        mnemonic = await invoke<string>('get_decrypted_mnemonic', {
-          password: currentPassword,
-        })
-      } catch (err) {
-        const msg = String(err)
-        if (msg.includes('No mnemonic stored')) {
-          // Switch to seed-phrase input mode
-          setNeedsSeedPhrase(true)
-          setError(null)
-          setIsLoading(false)
-          return
-        }
+    // 1. Verify the current password locally (and grab the mnemonic so we can
+    //    keep the local encrypted copy — used by the recovery-phrase viewer —
+    //    in sync). Restored wallets may have no local mnemonic; that's fine,
+    //    the node still validates the current password during /changepassword.
+    let mnemonic: string | null = null
+    try {
+      mnemonic = await invoke<string>('get_decrypted_mnemonic', {
+        password: currentPassword,
+      })
+    } catch (err) {
+      if (!String(err).includes('No mnemonic stored')) {
         setError(
           t(
             'changePassword.errorWrongPassword',
@@ -124,20 +135,60 @@ export const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
         setIsLoading(false)
         return
       }
+      // No local mnemonic — proceed without a local copy to re-encrypt.
     }
 
-    try {
-      await invoke('store_encrypted_mnemonic', {
-        accountName,
-        mnemonic,
-        password: newPassword,
-      })
-      setSuccess(true)
-    } catch (err) {
-      setError(String(err))
-    } finally {
+    // 2. Lock the node — required before /changepassword. If this fails the
+    //    node is still unlocked and the session is unharmed.
+    setProgress(t('changePassword.progressLocking', 'Locking wallet…'))
+    const lockRes = await lock()
+    if ('error' in lockRes) {
+      setError(
+        t('changePassword.errorLock', {
+          defaultValue: 'Could not lock the wallet: {{msg}}',
+          msg: messageOf(lockRes.error, 'unknown error'),
+        })
+      )
+      setProgress(null)
       setIsLoading(false)
+      return
     }
+
+    // 3. Change the password on the node (it re-encrypts the mnemonic file and
+    //    re-validates the current password + new-password strength).
+    setProgress(t('changePassword.progressUpdating', 'Updating password…'))
+    const cpRes = await changePassword({
+      new_password: newPassword,
+      old_password: currentPassword,
+    })
+    if ('error' in cpRes) {
+      // Node is now locked but the password is UNCHANGED — the user must
+      // unlock with their current password.
+      setError(messageOf(cpRes.error, t('changePassword.errorGeneric')))
+      setPhase('locked-unchanged')
+      setProgress(null)
+      setIsLoading(false)
+      return
+    }
+
+    // 4. Best-effort: re-encrypt the local mnemonic copy with the new password
+    //    so the recovery-phrase viewer keeps working. The node password has
+    //    already changed, so a failure here is non-fatal.
+    if (mnemonic) {
+      try {
+        await invoke('store_encrypted_mnemonic', {
+          accountName,
+          mnemonic,
+          password: newPassword,
+        })
+      } catch (err) {
+        console.error('Failed to re-encrypt local mnemonic copy:', err)
+      }
+    }
+
+    setPhase('changed')
+    setProgress(null)
+    setIsLoading(false)
   }
 
   const pos = getModalPositionClass()
@@ -158,6 +209,7 @@ export const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
         <input
           autoComplete={autoComplete}
           className="w-full rounded-lg border border-border-default/50 bg-surface-overlay/40 px-3 py-2.5 pr-10 text-sm text-white placeholder:text-content-tertiary focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/30 transition-colors"
+          disabled={isLoading}
           onChange={(e) => onChange(e.target.value)}
           placeholder="••••••••"
           type={show ? 'text' : 'password'}
@@ -166,6 +218,7 @@ export const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
         <button
           className="absolute right-3 top-1/2 -translate-y-1/2 text-content-tertiary hover:text-content-secondary transition-colors"
           onClick={() => setShow(!show)}
+          tabIndex={-1}
           type="button"
         >
           {show ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
@@ -174,175 +227,165 @@ export const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
     </div>
   )
 
+  const renderBody = () => {
+    if (phase === 'changed') {
+      return (
+        <div className="flex flex-col items-center gap-4 py-6 text-center">
+          <div className="w-14 h-14 rounded-2xl bg-status-success/10 border border-status-success/20 flex items-center justify-center">
+            <CheckCircle2 className="w-7 h-7 text-status-success" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-base font-semibold text-white">
+              {t('changePassword.successTitle', 'Password updated')}
+            </p>
+            <p className="text-sm text-content-secondary">
+              {t(
+                'changePassword.successDescription',
+                'Your wallet has been locked. Unlock it with your new password to continue.'
+              )}
+            </p>
+          </div>
+          <button
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary hover:bg-primary-emphasis px-6 text-sm font-semibold text-primary-foreground transition-colors"
+            onClick={goToUnlock}
+            type="button"
+          >
+            <Lock className="w-4 h-4" />
+            {t('changePassword.unlockNow', 'Unlock now')}
+          </button>
+        </div>
+      )
+    }
+
+    if (phase === 'locked-unchanged') {
+      return (
+        <div className="flex flex-col items-center gap-4 py-6 text-center">
+          <div className="w-14 h-14 rounded-2xl bg-status-danger/10 border border-status-danger/20 flex items-center justify-center">
+            <AlertTriangle className="w-7 h-7 text-status-danger" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-base font-semibold text-white">
+              {t('changePassword.failedTitle', 'Password not changed')}
+            </p>
+            <p className="text-sm text-content-secondary">
+              {error ||
+                t('changePassword.errorGeneric', 'Failed to change password.')}
+            </p>
+            <p className="text-sm text-content-secondary">
+              {t(
+                'changePassword.lockedUnchangedHint',
+                'Your wallet was locked but the password is unchanged — unlock with your current password.'
+              )}
+            </p>
+          </div>
+          <button
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary hover:bg-primary-emphasis px-6 text-sm font-semibold text-primary-foreground transition-colors"
+            onClick={goToUnlock}
+            type="button"
+          >
+            <Lock className="w-4 h-4" />
+            {t('changePassword.goToUnlock', 'Go to unlock')}
+          </button>
+        </div>
+      )
+    }
+
+    return (
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <p className="text-sm text-content-secondary leading-relaxed">
+          {t(
+            'changePassword.description',
+            'Enter your current password and choose a new one. Your wallet will be locked while the password is changed, then you can unlock it with the new password.'
+          )}
+        </p>
+
+        {passwordInput(
+          t('changePassword.currentPassword', 'Current password'),
+          currentPassword,
+          setCurrentPassword,
+          showCurrent,
+          setShowCurrent,
+          'current-password'
+        )}
+        {passwordInput(
+          t('changePassword.newPassword', 'New password'),
+          newPassword,
+          setNewPassword,
+          showNew,
+          setShowNew,
+          'new-password'
+        )}
+        {passwordInput(
+          t('changePassword.confirmPassword', 'Confirm new password'),
+          confirmPassword,
+          setConfirmPassword,
+          showConfirm,
+          setShowConfirm,
+          'new-password'
+        )}
+
+        {error && (
+          <p className="text-sm text-status-danger leading-relaxed">{error}</p>
+        )}
+
+        <div className="flex items-center justify-between pt-2">
+          <button
+            className="flex items-center gap-1.5 px-4 py-2.5 text-content-secondary hover:text-content-primary transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={isLoading}
+            onClick={handleClose}
+            type="button"
+          >
+            <X className="w-4 h-4" />
+            {t('common.cancel', 'Cancel')}
+          </button>
+          <button
+            className="flex items-center gap-2 px-4 py-2.5 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-md font-semibold transition-colors text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={
+              isLoading || !currentPassword || !newPassword || !confirmPassword
+            }
+            type="submit"
+          >
+            {isLoading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <KeyRound className="w-4 h-4" />
+            )}
+            {isLoading
+              ? progress || t('changePassword.updating', 'Updating…')
+              : t('changePassword.confirm', 'Update Password')}
+          </button>
+        </div>
+      </form>
+    )
+  }
+
+  const dismissable = phase === 'form' && !isLoading
+
   return createPortal(
     <div
       className={`${pos} inset-0 bg-surface-base/80 backdrop-blur-sm flex items-center justify-center z-50 p-4`}
-      onMouseDown={(e) => e.target === e.currentTarget && handleClose()}
+      onMouseDown={(e) =>
+        dismissable && e.target === e.currentTarget && handleClose()
+      }
     >
       <div className="w-full max-w-lg bg-surface-base rounded-3xl border border-border-subtle/50 shadow-2xl shadow-black/20 overflow-hidden relative">
         <div className="max-h-[85vh] overflow-y-auto px-8 py-8">
-          {/* Header */}
           <div className="flex items-center gap-3 pb-4 border-b border-divider/10 mb-6">
             <KeyRound className="w-6 h-6 text-primary" />
             <h3 className="text-xl font-bold text-white flex-1">
               {t('changePassword.title', 'Change Password')}
             </h3>
-            <button
-              className="p-1.5 rounded-md text-content-secondary hover:text-white hover:bg-surface-overlay/50 transition-colors"
-              onClick={handleClose}
-              type="button"
-            >
-              <X className="w-4 h-4" />
-            </button>
-          </div>
-
-          {success ? (
-            <div className="flex flex-col items-center gap-4 py-6 text-center">
-              <div className="w-14 h-14 rounded-2xl bg-status-success/10 border border-status-success/20 flex items-center justify-center">
-                <CheckCircle2 className="w-7 h-7 text-status-success" />
-              </div>
-              <div className="space-y-1">
-                <p className="text-base font-semibold text-white">
-                  {t('changePassword.successTitle', 'Password updated')}
-                </p>
-                <p className="text-sm text-content-secondary">
-                  {t(
-                    'changePassword.successDescription',
-                    'Your wallet password has been changed successfully.'
-                  )}
-                </p>
-              </div>
+            {dismissable && (
               <button
-                className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary hover:bg-primary-emphasis px-6 text-sm font-semibold text-[#12131C] transition-colors"
+                className="p-1.5 rounded-md text-content-secondary hover:text-white hover:bg-surface-overlay/50 transition-colors"
                 onClick={handleClose}
                 type="button"
               >
-                {t('common.close', 'Close')}
+                <X className="w-4 h-4" />
               </button>
-            </div>
-          ) : (
-            <form className="space-y-4" onSubmit={handleSubmit}>
-              {needsSeedPhrase ? (
-                <>
-                  {/* Seed phrase fallback notice */}
-                  <div className="flex gap-3 rounded-xl border border-amber-500/20 bg-amber-500/8 px-4 py-3">
-                    <AlertTriangle className="w-4 h-4 text-amber-400 flex-shrink-0 mt-0.5" />
-                    <p className="text-sm text-amber-200 leading-relaxed">
-                      {t(
-                        'changePassword.seedFallbackNotice',
-                        'Your recovery phrase is not stored in this device. Enter it below to enable password management.'
-                      )}
-                    </p>
-                  </div>
-
-                  {/* Seed phrase input */}
-                  <div className="space-y-1.5">
-                    <label className="text-xs font-medium text-content-secondary uppercase tracking-wider">
-                      {t('changePassword.seedPhrase', 'Recovery phrase')}
-                    </label>
-                    <textarea
-                      autoComplete="off"
-                      className="w-full rounded-lg border border-border-default/50 bg-surface-overlay/40 px-3 py-2.5 text-sm text-white placeholder:text-content-tertiary focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/30 transition-colors resize-none"
-                      onChange={(e) => setSeedPhrase(e.target.value)}
-                      placeholder={t(
-                        'changePassword.seedPhrasePlaceholder',
-                        'word1 word2 word3 …'
-                      )}
-                      rows={3}
-                      value={seedPhrase}
-                    />
-                  </div>
-
-                  {passwordInput(
-                    t('changePassword.newPassword', 'New password'),
-                    newPassword,
-                    setNewPassword,
-                    showNew,
-                    setShowNew,
-                    'new-password'
-                  )}
-                  {passwordInput(
-                    t('changePassword.confirmPassword', 'Confirm new password'),
-                    confirmPassword,
-                    setConfirmPassword,
-                    showConfirm,
-                    setShowConfirm,
-                    'new-password'
-                  )}
-                </>
-              ) : (
-                <>
-                  <p className="text-sm text-content-secondary leading-relaxed">
-                    {t(
-                      'changePassword.description',
-                      'Enter your current password, then choose a new one. Your wallet mnemonic will be re-encrypted with the new password.'
-                    )}
-                  </p>
-
-                  {passwordInput(
-                    t('changePassword.currentPassword', 'Current password'),
-                    currentPassword,
-                    setCurrentPassword,
-                    showCurrent,
-                    setShowCurrent,
-                    'current-password'
-                  )}
-                  {passwordInput(
-                    t('changePassword.newPassword', 'New password'),
-                    newPassword,
-                    setNewPassword,
-                    showNew,
-                    setShowNew,
-                    'new-password'
-                  )}
-                  {passwordInput(
-                    t('changePassword.confirmPassword', 'Confirm new password'),
-                    confirmPassword,
-                    setConfirmPassword,
-                    showConfirm,
-                    setShowConfirm,
-                    'new-password'
-                  )}
-                </>
-              )}
-
-              {/* Error */}
-              {error && (
-                <p className="text-sm text-status-danger leading-relaxed">
-                  {error}
-                </p>
-              )}
-
-              {/* Actions */}
-              <div className="flex items-center justify-between pt-2">
-                <button
-                  className="flex items-center gap-1.5 px-4 py-2.5 text-content-secondary hover:text-content-primary transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-                  disabled={isLoading}
-                  onClick={handleClose}
-                  type="button"
-                >
-                  <X className="w-4 h-4" />
-                  {t('common.cancel', 'Cancel')}
-                </button>
-                <button
-                  className="flex items-center gap-2 px-4 py-2.5 bg-[#15E99A] hover:bg-[#12C97E] text-gray-900 rounded-md font-semibold transition-colors text-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                  disabled={
-                    isLoading ||
-                    (!needsSeedPhrase &&
-                      (!currentPassword || !newPassword || !confirmPassword)) ||
-                    (needsSeedPhrase &&
-                      (!seedPhrase || !newPassword || !confirmPassword))
-                  }
-                  type="submit"
-                >
-                  <Save className="w-4 h-4" />
-                  {isLoading
-                    ? t('changePassword.updating', 'Updating…')
-                    : t('changePassword.confirm', 'Update Password')}
-                </button>
-              </div>
-            </form>
-          )}
+            )}
+          </div>
+          {renderBody()}
         </div>
       </div>
     </div>,

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -40,6 +40,7 @@ import { RootState } from '../../app/store'
 import { useAppSelector } from '../../app/store/hooks'
 import { AppVersion } from '../../components/AppVersion'
 import { BackupModal } from '../../components/BackupModal'
+import { ChangePasswordModal } from '../../components/ChangePasswordModal'
 import { MnemonicViewerModal } from '../../components/MnemonicViewer'
 import {
   ModalType,
@@ -130,6 +131,7 @@ export const Component: React.FC = () => {
   const [isSaving, setIsSaving] = useState(false)
   const [showRestartConfirmation, setShowRestartConfirmation] = useState(false)
   const [showMnemonicModal, setShowMnemonicModal] = useState(false)
+  const [showChangePasswordModal, setShowChangePasswordModal] = useState(false)
   const maxLogsFetchRetries = 3
 
   // Replace showModal with unified modal state
@@ -1040,15 +1042,12 @@ export const Component: React.FC = () => {
                 </div>
                 <ArrowRight className="w-4 h-4 text-content-secondary group-hover:translate-x-0.5 transition-transform" />
               </button>
-              {/* Change Password — coming soon. The node's /changepassword
-                  endpoint requires the wallet to be locked, so a correct
-                  implementation must lock → change → re-unlock (tracked as a
-                  follow-up). The previous flow only re-encrypted the local
-                  mnemonic copy without changing the node's unlock password,
-                  which silently diverged the two. Disabled until wired. */}
-              <div className="w-full flex items-center justify-between gap-3 p-4 rounded-xl border border-border-default/50 bg-surface-overlay/30 text-white opacity-60">
+              <button
+                className="w-full group flex items-center justify-between gap-3 p-4 rounded-xl border border-border-default/50 bg-surface-overlay/30 hover:bg-surface-elevated transition-colors text-white"
+                onClick={() => setShowChangePasswordModal(true)}
+              >
                 <div className="flex items-center gap-3">
-                  <div className="p-2 bg-primary/10 rounded-lg">
+                  <div className="p-2 bg-primary/10 rounded-lg group-hover:bg-primary/15 transition-colors">
                     <KeyRound className="w-4 h-4 text-primary" />
                   </div>
                   <div className="text-left">
@@ -1063,10 +1062,8 @@ export const Component: React.FC = () => {
                     </div>
                   </div>
                 </div>
-                <span className="flex-shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-surface-elevated text-content-secondary border border-border-default/50">
-                  {t('common.comingSoon', 'Coming soon')}
-                </span>
-              </div>
+                <ArrowRight className="w-4 h-4 text-content-secondary group-hover:translate-x-0.5 transition-transform" />
+              </button>
 
               <button
                 className="w-full group flex items-center justify-between gap-3 p-4 rounded-xl border border-border-default/50 bg-surface-overlay/30 hover:bg-surface-elevated transition-colors text-white"
@@ -1276,6 +1273,12 @@ export const Component: React.FC = () => {
       <MnemonicViewerModal
         isOpen={showMnemonicModal}
         onClose={() => setShowMnemonicModal(false)}
+      />
+
+      <ChangePasswordModal
+        accountName={currentAccount?.name ?? ''}
+        onClose={() => setShowChangePasswordModal(false)}
+        showModal={showChangePasswordModal}
       />
 
       <BackupModal

--- a/src/slices/nodeApi/nodeApi.slice.ts
+++ b/src/slices/nodeApi/nodeApi.slice.ts
@@ -55,6 +55,7 @@ import type {
   SignMessageResponse,
   SignMessageRequest,
   UnlockRequest,
+  ChangePasswordRequest,
   KeysendResponse,
   KeysendRequest,
   ListPeersResponse,
@@ -149,6 +150,11 @@ export const nodeApi = createApi({
 
     btcBalance: builder.query<BtcBalanceResponse, void>({
       queryFn: queryFn((w, _: void) => w.getBtcBalance()),
+    }),
+
+    // Node requires the wallet to be LOCKED before this succeeds.
+    changePassword: builder.mutation<void, ChangePasswordRequest>({
+      queryFn: queryFn((w, args) => w.changePassword(args)),
     }),
 
     closeChannel: builder.mutation<void, CloseChannelRequest>({
@@ -340,6 +346,7 @@ export const {
   useAssetBalanceQuery,
   useBackupMutation,
   useBtcBalanceQuery,
+  useChangePasswordMutation,
   useCloseChannelMutation,
   useConnectPeerMutation,
   useCreateUtxosMutation,


### PR DESCRIPTION
## What
Re-implements the **Change Password** feature that was disabled in #143 (it only re-encrypted the local mnemonic copy and never changed the node's unlock password — the two silently diverged). Closes the Change-Password half of #144.

## How
- Adds `changePassword` to `NodeApiWrapper` + a `changePassword` mutation/`useChangePasswordMutation` hook in `nodeApi` (the SDK's `RlnClient` already exposes it).
- Rewrites `ChangePasswordModal` to run the correct flow:
  1. **Verify** the current password locally (via `get_decrypted_mnemonic`) and grab the mnemonic (restored wallets with no local copy are handled — the node still validates the password).
  2. **Lock** the node — the node's `/changepassword` returns 403 while unlocked.
  3. **POST /changepassword** `{old_password, new_password}` (node re-encrypts the mnemonic file + validates old password & new-password strength).
  4. **Best-effort re-encrypt** the local mnemonic copy with the new password so the recovery-phrase viewer stays in sync (non-fatal on failure — node password already changed).
  5. **Route to the standard unlock screen** to re-enter with the new password (reuses the battle-tested unlock flow incl. full node config + retry instead of reimplementing it).
- Recoverable failure paths: lock fails → session untouched; change fails → wallet locked but password **unchanged**, UI tells the user to unlock with their current password.
- Drops the old unvalidated seed-phrase fallback (not needed to change the node password).
- Re-enables the Settings entry (was 'Coming soon'). **Auto Time-Lock stays 'Coming soon'** — separate feature, still tracked in #144.

## Testing
- `tsc` + `vite build` green.
- ⚠️ **Needs on-device verification** — the node lock/unlock lifecycle can't be exercised here. Please verify on a real node:
  - [ ] change password → land on unlock → unlock with the **new** password succeeds
  - [ ] recovery-phrase viewer works with the new password afterward
  - [ ] wrong current password is rejected **before** locking
  - [ ] a rejected new password (e.g. too weak for the node) leaves you able to unlock with the **current** password

Refs #143 #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)