### PR TITLE
feat: docker-regtest connect preset, LN-only deposit max, pending-invoice history filter

### DIFF
--- a/src/components/Layout/Modal/Deposit/Step2.tsx
+++ b/src/components/Layout/Modal/Deposit/Step2.tsx
@@ -47,7 +47,6 @@ interface Props {
 }
 
 const MSATS_PER_SAT = 1000
-const RGB_HTLC_MIN_SAT = 3000
 const SATOSHIS_PER_BTC = 100_000_000
 
 export const Step2 = ({ assetId, onBack, onClose, onNext }: Props) => {
@@ -229,24 +228,21 @@ export const Step2 = ({ assetId, onBack, onClose, onNext }: Props) => {
   const calculateMaxDepositAmount = useCallback(
     (asset: string): number => {
       if (asset === 'BTC') {
-        if (channels.length === 0) {
+        // A deposit RECEIVES over Lightning, so the ceiling is inbound
+        // liquidity (the peer's balance we can pull), taken as the largest
+        // single usable channel — NOT next_outbound_htlc_limit_msat, which is
+        // our *send* limit. This bound is Lightning-only; on-chain deposits
+        // are unlimited.
+        const usableChannels = channels.filter((c: Channel) => c.is_usable)
+        if (usableChannels.length === 0) {
           return 0
         }
 
-        const channelHtlcLimits = channels.map(
-          (c: Channel) => (c.next_outbound_htlc_limit_msat ?? 0) / MSATS_PER_SAT
+        const inboundSats = usableChannels.map(
+          (c: Channel) => (c.inbound_balance_msat ?? 0) / MSATS_PER_SAT
         )
 
-        if (
-          channelHtlcLimits.length === 0 ||
-          Math.max(...channelHtlcLimits) <= 0
-        ) {
-          return 0
-        }
-
-        const maxHtlcLimit = Math.max(...channelHtlcLimits)
-        const maxDepositableAmount = maxHtlcLimit - RGB_HTLC_MIN_SAT
-        return Math.max(0, maxDepositableAmount)
+        return Math.max(0, Math.max(...inboundSats))
       } else {
         const assetChannels = channels.filter(
           (c: Channel) => c.asset_id === asset && c.is_usable
@@ -792,7 +788,11 @@ export const Step2 = ({ assetId, onBack, onClose, onNext }: Props) => {
               </div>
               {maxDepositAmount > 0 && (
                 <p className="text-xs text-content-secondary pt-0.5">
-                  Max: {formatAmount(maxDepositAmount, 'BTC')}{' '}
+                  {t(
+                    'depositModal.step2.amount.maxLightning',
+                    'Max via Lightning'
+                  )}
+                  : {formatAmount(maxDepositAmount, 'BTC')}{' '}
                   {bitcoinUnit === 'SAT' ? 'SATS' : bitcoinUnit}
                 </p>
               )}

--- a/src/components/RegtestConnectionSelector/index.tsx
+++ b/src/components/RegtestConnectionSelector/index.tsx
@@ -1,4 +1,4 @@
-import { Server, Globe, Check } from 'lucide-react'
+import { Server, Globe, Check, Container } from 'lucide-react'
 import { useState } from 'react'
 
 import { RegtestConnectionType } from '../../constants'
@@ -35,6 +35,21 @@ const connectionOptions: ConnectionOption[] = [
     icon: <Globe className="w-5 h-5" />,
     title: 'Remote (Bitfinex Regtest)',
     type: 'bitfinex',
+  },
+  {
+    badge: 'Docker',
+    badgeVariant: 'warning',
+    description:
+      'Connect to a node started by the kaleidoswap-maker Docker stack',
+    details: [
+      'Node on localhost:3001 (make start-channels)',
+      'Backends via docker hostnames (bitcoind / esplora)',
+      'Indexer http://esplora:3000',
+      'Default wallet password prefilled',
+    ],
+    icon: <Container className="w-5 h-5" />,
+    title: 'Local Docker Regtest',
+    type: 'docker',
   },
   {
     badge: 'Local',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,7 +23,7 @@ const NETWORK_DISPLAY_NAMES: Record<string, string> = {
 export const getNetworkDisplayName = (network: string): string =>
   NETWORK_DISPLAY_NAMES[network] ?? network
 
-export type RegtestConnectionType = 'local' | 'bitfinex'
+export type RegtestConnectionType = 'local' | 'bitfinex' | 'docker'
 
 // Error constants
 export const ERROR_NOT_ENOUGH_UNCOLORED =

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -18,6 +18,19 @@ export const NETWORK_DEFAULTS: Record<string, NetworkDefaults> = {
     proxy_endpoint: 'rpcs://proxy.iriswallet.com/0.2/json-rpc',
     rpc_connection_url: 'user:password@regtest-bitcoind.rgbtools.org:80',
   },
+  // Node started by the kaleidoswap-maker docker stack (`make start-channels`).
+  // The rgb-lightning-node runs INSIDE the compose network, so it reaches its
+  // backends via docker-internal hostnames (bitcoind / esplora / myproxy.local),
+  // not localhost — even though the desktop connects to it on localhost:3001.
+  LocalDockerRegtest: {
+    daemon_listening_port: '3001',
+    default_lsp_url: 'http://localhost:8000/',
+    default_maker_url: 'http://localhost:8000/',
+    indexer_url: 'http://esplora:3000',
+    ldk_peer_listening_port: '9735',
+    proxy_endpoint: 'rpc://myproxy.local:3000/json-rpc',
+    rpc_connection_url: 'user:password@bitcoind:18443',
+  },
   LocalRegtest: {
     daemon_listening_port: '3001',
     default_lsp_url: 'http://localhost:8000/',

--- a/src/routes/wallet-history/deposits/index.tsx
+++ b/src/routes/wallet-history/deposits/index.tsx
@@ -201,7 +201,15 @@ export const Component: React.FC = () => {
       if (typeFilter !== 'all' && deposit.type !== typeFilter) return false
       if (assetFilter !== 'all' && assetLabel(deposit) !== assetFilter)
         return false
-      if (statusFilter !== 'all') {
+      if (statusFilter === 'pending-invoice') {
+        // Unpaid, zero-amount Lightning invoices generated to receive BTC.
+        const isPendingZeroInvoice =
+          deposit.type === 'off-chain' &&
+          (deposit.status ?? '').toLowerCase() === 'pending' &&
+          !deposit.rgbAssetId &&
+          parseFloat(deposit.satAmount || '0') === 0
+        if (!isPendingZeroInvoice) return false
+      } else if (statusFilter !== 'all') {
         const depositStatus = deposit.status ?? 'Completed'
         if (depositStatus.toLowerCase() !== statusFilter.toLowerCase())
           return false
@@ -403,6 +411,10 @@ export const Component: React.FC = () => {
               { label: t('deposits.completed'), value: 'Completed' },
               { label: t('deposits.pending'), value: 'Pending' },
               { label: t('deposits.failed'), value: 'Failed' },
+              {
+                label: t('deposits.pendingInvoices', 'Pending invoices'),
+                value: 'pending-invoice',
+              },
             ]}
             value={statusFilter}
           />

--- a/src/routes/wallet-remote/index.tsx
+++ b/src/routes/wallet-remote/index.tsx
@@ -461,10 +461,13 @@ export const Component = () => {
 
       // Handle regtest connection type selection
       if (data.network === 'Regtest' && data.regtestConnectionType) {
-        networkKey =
-          data.regtestConnectionType === 'local'
-            ? 'LocalRegtest'
-            : 'BitfinexRegtest'
+        if (data.regtestConnectionType === 'local') {
+          networkKey = 'LocalRegtest'
+        } else if (data.regtestConnectionType === 'docker') {
+          networkKey = 'LocalDockerRegtest'
+        } else {
+          networkKey = 'BitfinexRegtest'
+        }
       }
 
       const networkDefaults = NETWORK_DEFAULTS[networkKey]
@@ -537,18 +540,20 @@ export const Component = () => {
 
   const selectedNetwork = form.watch('network')
   const regtestConnectionType = form.watch('regtestConnectionType')
+  // Both 'local' and 'docker' target a localhost node; only 'bitfinex' is remote.
+  const isLocalRegtest =
+    regtestConnectionType === 'local' || regtestConnectionType === 'docker'
   const nodeUrlDescription =
     selectedNetwork === 'Regtest'
       ? t('walletRemote.nodeUrlDescriptionRegtest', {
-          type:
-            regtestConnectionType === 'local'
-              ? t('walletRemote.regtestTypeLocal')
-              : t('walletRemote.regtestTypeBitfinex'),
+          type: isLocalRegtest
+            ? t('walletRemote.regtestTypeLocal')
+            : t('walletRemote.regtestTypeBitfinex'),
         })
       : t('walletRemote.nodeUrlDescription')
   const nodeUrlPlaceholder =
     selectedNetwork === 'Regtest'
-      ? regtestConnectionType === 'local'
+      ? isLocalRegtest
         ? t('walletRemote.nodeUrlPlaceholderRegtest')
         : t('walletRemote.nodeUrlPlaceholderBitfinex')
       : t('walletRemote.nodeUrlPlaceholder')

--- a/src/routes/wallet-remote/index.tsx
+++ b/src/routes/wallet-remote/index.tsx
@@ -105,10 +105,13 @@ export const Component = () => {
 
         // Handle regtest connection type selection
         if (value.network === 'Regtest' && value.regtestConnectionType) {
-          networkKey =
-            value.regtestConnectionType === 'local'
-              ? 'LocalRegtest'
-              : 'BitfinexRegtest'
+          if (value.regtestConnectionType === 'local') {
+            networkKey = 'LocalRegtest'
+          } else if (value.regtestConnectionType === 'docker') {
+            networkKey = 'LocalDockerRegtest'
+          } else {
+            networkKey = 'BitfinexRegtest'
+          }
         }
 
         const defaults = NETWORK_DEFAULTS[networkKey]
@@ -125,6 +128,12 @@ export const Component = () => {
             'node_url',
             `http://localhost:${defaults.daemon_listening_port}`
           )
+          // The maker docker stack ships a fixed regtest wallet password —
+          // prefill it so the node started by `make start-channels` unlocks
+          // out of the box.
+          if (value.regtestConnectionType === 'docker') {
+            form.setValue('password', 'password')
+          }
         }
       }
     })


### PR DESCRIPTION
Three small additions requested for the local-dev + deposit UX.

## 1. Remote connect → 'Local Docker Regtest' preset
New `regtestConnectionType: 'docker'` card in the remote-connect flow + `NETWORK_DEFAULTS.LocalDockerRegtest`. Because `make start-channels` runs the rgb-lightning-node **inside** the kaleidoswap-maker compose network, the node resolves its backends via docker-internal hostnames — so the preset fills:
- `rpc_connection_url: user:password@bitcoind:18443`
- `indexer_url: http://esplora:3000`
- `proxy_endpoint: rpc://myproxy.local:3000/json-rpc`
- `node_url: http://localhost:3001` (host → node) + the fixed regtest wallet password prefilled.

One click to unlock a node from `make start-channels` on :3001. (The existing 'Local Regtest' preset — localhost backends, for a host-run node — is unchanged.)

## 2. BTC deposit max = inbound HTLC across channels, LN-only
A deposit *receives* over Lightning, so the ceiling should be **inbound** liquidity. Changed the BTC max from `next_outbound_htlc_limit_msat` (our *send* limit — wrong for a receive) to the largest `inbound_balance_msat` across **usable** channels, and relabelled the hint 'Max via Lightning' so it's clear the cap applies only to LN — on-chain deposits stay unlimited. (The zero-amount invoice is already auto-generated when BTC is selected, on Step2 mount — no button press needed.)

## 3. Deposit history → 'Pending invoices' filter
New status-filter option that isolates unpaid zero-amount inbound Lightning invoices (off-chain, Pending, 0 sat, BTC) so you can see outstanding receive invoices.

## Testing
- `tsc` + `vite build` green.
- ⚠️ **Needs on-device verification** — node connect/unlock, channel liquidity, and invoice generation can't be exercised without a live node:
  - [ ] 'Local Docker Regtest' preset unlocks a `make start-channels` node on :3001
  - [ ] BTC deposit shows 'Max via Lightning' = largest inbound channel; on-chain amount not capped
  - [ ] Deposit history 'Pending invoices' lists unpaid zero-amount invoices

🤖 Generated with [Claude Code](https://claude.com/claude-code)