### PR TITLE
Release v0.5.0 (retag) — promote dev to main

### DIFF
--- a/src/components/Layout/config.tsx
+++ b/src/components/Layout/config.tsx
@@ -313,7 +313,7 @@ export const getSupportResources = (t: TFunction) => [
     description: t('support.faqDesc'),
     icon: <HelpCircle className="w-4 h-4" />,
     name: t('support.faq'),
-    url: 'https://docs.kaleidoswap.com/desktop-app/faq',
+    url: 'https://docs.kaleidoswap.com/desktop-app/support/faq',
   },
   {
     description: t('support.telegramGroupDesc'),

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,4 +1,3 @@
-import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
 import Decimal from 'decimal.js'
@@ -30,10 +29,10 @@ import {
 } from '../../app/router/paths'
 import { useAppDispatch, useAppSelector } from '../../app/store/hooks'
 import logoFull from '../../assets/logo-full.svg'
+import { isBtcWalletTx } from '../../helpers/walletHistoryUtils'
 import { useNodeLifecycleEvents } from '../../hooks/useNodeLifecycleEvents'
 import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 import { nodeApi } from '../../slices/nodeApi/nodeApi.slice'
-import { setNodeReachability } from '../../slices/node/node.slice'
 import { nodeSettingsActions } from '../../slices/nodeSettings/nodeSettings.slice'
 import {
   setAppMode,
@@ -48,6 +47,7 @@ import { useDcaScheduler } from '../../hooks/useDcaScheduler'
 import { useLimitOrderScheduler } from '../../hooks/useLimitOrderScheduler'
 import { useNwcAutostart } from '../../hooks/useNwcAutostart'
 import { useNodeReachabilityMonitor } from '../../hooks/useNodeReachabilityMonitor'
+import { useNodeReconnect } from '../../hooks/useNodeReconnect'
 import { LogoutModal, LogoutButton } from '../LogoutModal'
 import { useNotification } from '../NotificationSystem'
 import { ShutdownAnimation } from '../ShutdownAnimation'
@@ -71,43 +71,6 @@ import { LayoutModal } from './Modal'
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 const DEFAULT_TOAST_AUTO_CLOSE_MS = 5000
-
-const getNodeErrorMessage = (error: unknown) => {
-  if (!error) return 'Unknown node connection error'
-  if (typeof error === 'string') return error
-
-  if (typeof error === 'object' && error !== null) {
-    if ('error' in error && typeof error.error === 'string') {
-      return error.error
-    }
-
-    if ('data' in error) {
-      const data = error.data
-      if (typeof data === 'string') return data
-      if (typeof data === 'object' && data !== null && 'error' in data) {
-        return String(data.error)
-      }
-    }
-  }
-
-  return String(error)
-}
-
-const isNodeReachabilityError = (error: FetchBaseQueryError) => {
-  if (error.status === 'FETCH_ERROR' || error.status === 'TIMEOUT_ERROR') {
-    return true
-  }
-
-  const message = getNodeErrorMessage(error).toLowerCase()
-  return (
-    message.includes('failed to fetch') ||
-    message.includes('load failed') ||
-    message.includes('network') ||
-    message.includes('timeout') ||
-    message.includes('connection refused') ||
-    message.includes('connection reset')
-  )
-}
 
 interface Props {
   className?: string
@@ -349,6 +312,7 @@ const UserProfile = ({
   const accountName = useAppSelector((state) => state.nodeSettings.data.name)
   const nodeSettingsData = useAppSelector((state) => state.nodeSettings.data)
   const nodeReachability = useAppSelector((state) => state.node.reachability)
+  const { reconnect, isReconnecting } = useNodeReconnect()
   const isNodeReachable =
     nodeReachability === 'reachable' ||
     (nodeReachability === 'unknown' && nodeInfo.isSuccess)
@@ -504,6 +468,41 @@ const UserProfile = ({
             </div>
           )}
 
+          {/* Node configured but not reachable — offer a manual reconnect
+              without waiting for the auto-retry / blocking overlay. */}
+          {hasNode && !isNodeReachable && (
+            <div className="py-1 border-b border-divider/20">
+              <button
+                className="w-full px-4 py-3 flex items-center space-x-3 cursor-pointer
+                          hover:bg-gradient-to-r hover:from-primary/10 hover:to-transparent
+                          transition-all duration-200 group
+                          disabled:opacity-60 disabled:cursor-not-allowed"
+                disabled={isReconnecting}
+                onClick={() => {
+                  reconnect()
+                }}
+                type="button"
+              >
+                <div className="text-primary transition-transform duration-200 group-hover:scale-110">
+                  {isReconnecting ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <RefreshCw className="w-4 h-4" />
+                  )}
+                </div>
+                <span className="text-sm font-medium group-hover:text-white">
+                  {isReconnecting
+                    ? t('userProfile.reconnecting', {
+                        defaultValue: 'Reconnecting…',
+                      })
+                    : t('userProfile.reconnect', {
+                        defaultValue: 'Reconnect node',
+                      })}
+                </span>
+              </button>
+            </div>
+          )}
+
           <div className="py-1">
             {USER_MENU_ITEMS.map((item) => (
               <div
@@ -546,8 +545,10 @@ export const Layout = (props: Props) => {
   const [isChannelMenuOpen, setIsChannelMenuOpen] = useState(false)
   const [isTransactionMenuOpen, setIsTransactionMenuOpen] = useState(false)
   const [isSupportMenuOpen, setIsSupportMenuOpen] = useState(false)
-  const [isRetryingNodeConnection, setIsRetryingNodeConnection] =
-    useState(false)
+  const {
+    reconnect: retryNodeConnection,
+    isReconnecting: isRetryingNodeConnection,
+  } = useNodeReconnect()
 
   const [showSupportModal, setShowSupportModal] = useState(false)
 
@@ -742,7 +743,7 @@ export const Layout = (props: Props) => {
         (data?.transactions || [])
           .filter(
             (tx: any) =>
-              tx.transaction_type === 'User' &&
+              isBtcWalletTx(tx.transaction_type) &&
               new Decimal(tx.received ?? 0).minus(tx.sent ?? 0).gt(0)
           )
           .map((tx: any) => ({
@@ -842,36 +843,6 @@ export const Layout = (props: Props) => {
         type: type as ModalActionType,
       })
     )
-  }
-
-  const handleRetryNodeConnection = async () => {
-    setIsRetryingNodeConnection(true)
-    try {
-      const result = await dispatch(
-        nodeApi.endpoints.nodeInfo.initiate(undefined, {
-          forceRefetch: true,
-          subscribe: false,
-        })
-      )
-
-      if ('error' in result && result.error) {
-        const error = result.error as FetchBaseQueryError
-
-        if (isNodeReachabilityError(error)) {
-          dispatch(
-            setNodeReachability({
-              error: getNodeErrorMessage(error),
-              status: 'unreachable',
-            })
-          )
-          return
-        }
-      }
-
-      dispatch(setNodeReachability({ status: 'reachable' }))
-    } finally {
-      setIsRetryingNodeConnection(false)
-    }
   }
 
   const handleKeepRunningInBackground = async () => {
@@ -1002,7 +973,9 @@ export const Layout = (props: Props) => {
                   <button
                     className="px-4 py-3 rounded-md bg-primary text-primary-foreground font-medium disabled:opacity-60 flex items-center justify-center gap-2"
                     disabled={isRetryingNodeConnection}
-                    onClick={handleRetryNodeConnection}
+                    onClick={() => {
+                      retryNodeConnection()
+                    }}
                   >
                     {isRetryingNodeConnection ? (
                       <Loader2 className="w-4 h-4 animate-spin" />

--- a/src/components/SupportModal/index.tsx
+++ b/src/components/SupportModal/index.tsx
@@ -159,7 +159,7 @@ export const SupportModal = ({ isOpen, onClose }: SupportModalProps) => {
                   className="bg-surface-overlay/50 border border-divider/20 rounded-xl p-4 cursor-pointer hover:bg-surface-elevated/30 transition-colors duration-200 group"
                   onClick={() =>
                     openExternalLink(
-                      'https://docs.kaleidoswap.com/desktop-app/faq'
+                      'https://docs.kaleidoswap.com/desktop-app/support/faq'
                     )
                   }
                 >

--- a/src/components/wallet-setup/RemoteNodeInfo.tsx
+++ b/src/components/wallet-setup/RemoteNodeInfo.tsx
@@ -32,7 +32,9 @@ export const RemoteNodeInfo: React.FC = () => {
               className="border-primary/30 text-primary hover:bg-primary/10"
               icon={<ExternalLink className="w-3.5 h-3.5" />}
               onClick={() =>
-                openUrl('https://docs.kaleidoswap.com/desktop-app/node-hosting')
+                openUrl(
+                  'https://docs.kaleidoswap.com/desktop-app/getting-started/node-hosting'
+                )
               }
               size="sm"
               variant="outline"

--- a/src/hooks/useNodeReconnect.ts
+++ b/src/hooks/useNodeReconnect.ts
@@ -1,0 +1,86 @@
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import { useCallback, useState } from 'react'
+
+import { useAppDispatch } from '../app/store/hooks'
+import { setNodeReachability } from '../slices/node/node.slice'
+import { nodeApi } from '../slices/nodeApi/nodeApi.slice'
+
+const getNodeErrorMessage = (error: unknown) => {
+  if (!error) return 'Unknown node connection error'
+  if (typeof error === 'string') return error
+
+  if (typeof error === 'object' && error !== null) {
+    if ('error' in error && typeof error.error === 'string') {
+      return error.error
+    }
+
+    if ('data' in error) {
+      const data = error.data
+      if (typeof data === 'string') return data
+      if (typeof data === 'object' && data !== null && 'error' in data) {
+        return String(data.error)
+      }
+    }
+  }
+
+  return String(error)
+}
+
+const isNodeReachabilityError = (error: FetchBaseQueryError) => {
+  if (error.status === 'FETCH_ERROR' || error.status === 'TIMEOUT_ERROR') {
+    return true
+  }
+
+  const message = getNodeErrorMessage(error).toLowerCase()
+  return (
+    message.includes('failed to fetch') ||
+    message.includes('load failed') ||
+    message.includes('network') ||
+    message.includes('timeout') ||
+    message.includes('connection refused') ||
+    message.includes('connection reset')
+  )
+}
+
+/**
+ * Manually re-probe the node and update its reachability. Shared by the
+ * blocking "node offline" overlay and the user-menu reconnect button so both
+ * trigger the exact same forced nodeInfo refetch and reachability update.
+ * Returns true when the node responded, false when it's still unreachable.
+ */
+export const useNodeReconnect = () => {
+  const dispatch = useAppDispatch()
+  const [isReconnecting, setIsReconnecting] = useState(false)
+
+  const reconnect = useCallback(async () => {
+    setIsReconnecting(true)
+    try {
+      const result = await dispatch(
+        nodeApi.endpoints.nodeInfo.initiate(undefined, {
+          forceRefetch: true,
+          subscribe: false,
+        })
+      )
+
+      if ('error' in result && result.error) {
+        const error = result.error as FetchBaseQueryError
+        if (isNodeReachabilityError(error)) {
+          dispatch(
+            setNodeReachability({
+              error: getNodeErrorMessage(error),
+              status: 'unreachable',
+            })
+          )
+          return false
+        }
+      }
+
+      dispatch(setNodeReachability({ status: 'reachable' }))
+      return true
+    } finally {
+      setIsReconnecting(false)
+    }
+  }, [dispatch])
+
+  return { isReconnecting, reconnect }
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -132,6 +132,8 @@
     "noNode": "No node connected",
     "tapToConnect": "Tap to connect",
     "connectNode": "Connect a node",
+    "reconnect": "Reconnect node",
+    "reconnecting": "Reconnecting…",
     "logout": "Logout",
     "settings": "Settings"
   },
@@ -1499,6 +1501,8 @@
     }
   },
   "orderChannel": {
+    "creatingOrder": "Creating your order…",
+    "creatingOrderHint": "Contacting the LSP to reserve your channel. This can take a few seconds.",
     "step1": {
       "title": "LSP Connection",
       "subtitle": "Connect to a Lightning Service Provider to get started",
@@ -1568,6 +1572,13 @@
     "step2": {
       "title": "Configure Channel",
       "subtitle": "Set up your channel parameters and capacity",
+      "intro": {
+        "title": "Configure your channel",
+        "stepCapacity": "Choose the total channel capacity — the larger it is, the more you can send and receive.",
+        "stepOutbound": "Set how much starts on your side (outbound, ready to send). The rest is inbound — what you can receive.",
+        "stepAsset": "Optionally add an RGB asset and pick how long the channel stays open.",
+        "stepReview": "Check the total cost breakdown at the bottom, then continue to review and pay."
+      },
       "stepLabel": "Step {{current}} of {{total}}",
       "step1Label": "Connect",
       "step2Label": "Configure",

--- a/src/routes/order-new-channel/Step2.tsx
+++ b/src/routes/order-new-channel/Step2.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { ArrowLeft, ArrowRight, ChevronDown } from 'lucide-react'
+import { ArrowLeft, ArrowRight, ChevronDown, Info } from 'lucide-react'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -702,435 +702,467 @@ export const Step2: React.FC<Props> = ({
             <Spinner color="#15E99A" overlay={false} size={48} />
           </div>
         ) : (
-          <div className="bg-surface-overlay/50 backdrop-blur-sm rounded-xl border border-border-default/50 p-8">
-            {/* Channel Capacity */}
-            <div className="mb-12">
-              <div className="flex items-center justify-between mb-2">
-                <div className="flex items-center gap-1.5">
-                  <label className="text-sm font-medium text-content-secondary">
-                    {t('orderChannel.step2.channelCapacity')}
-                  </label>
-                  <InfoHint content="The total size of the channel, in sats. A larger capacity lets you send and receive more, but costs more on-chain to open." />
-                </div>
-                <div className="flex items-center gap-1">
-                  {[
-                    { label: '100k', value: 100_000 },
-                    { label: '250k', value: 250_000 },
-                    { label: '500k', value: 500_000 },
-                    { label: '1M', value: 1_000_000 },
-                  ].map(({ label, value }) => (
-                    <button
-                      className={`px-2 py-0.5 rounded text-xs font-semibold border transition-colors ${
-                        value > effectiveMaxCapacity
-                          ? 'opacity-30 cursor-not-allowed bg-surface-high/40 border-border-default/40 text-content-secondary'
-                          : 'bg-surface-high/40 border-border-default/40 text-content-secondary hover:text-white hover:border-border-default/70'
-                      }`}
-                      disabled={value > effectiveMaxCapacity}
-                      key={label}
-                      onClick={() => handleCapacityChange(value.toString())}
-                      type="button"
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
+          <>
+            {/* Guidance — tell the user what this step is for and what to do */}
+            <div className="mb-6 flex items-start gap-3 rounded-xl border border-primary/20 bg-primary/5 p-4">
+              <Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" />
+              <div className="space-y-1.5">
+                <p className="text-sm font-semibold text-white">
+                  {t('orderChannel.step2.intro.title')}
+                </p>
+                <ol className="list-decimal space-y-1 pl-4 text-xs text-content-secondary marker:text-content-tertiary">
+                  <li>{t('orderChannel.step2.intro.stepCapacity')}</li>
+                  <li>{t('orderChannel.step2.intro.stepOutbound')}</li>
+                  <li>{t('orderChannel.step2.intro.stepAsset')}</li>
+                  <li>{t('orderChannel.step2.intro.stepReview')}</li>
+                </ol>
               </div>
-              <div className="relative">
-                <input
-                  className="w-full pl-4 pr-20 py-2 bg-surface-base/50 rounded-lg border border-border-default/30 text-white text-2xl font-semibold focus:border-primary/60 focus:ring-2 focus:ring-primary/15 placeholder:text-content-tertiary/50 h-14 hover:border-border-default/50 focus:outline-none"
-                  onChange={(e) => handleCapacityChange(e.target.value)}
-                  placeholder="0"
-                  type="text"
-                  value={
-                    currentCapacity > 0 ? formatNumber(currentCapacity) : ''
-                  }
-                />
-                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-content-tertiary/50 text-sm font-semibold pointer-events-none select-none tracking-wide border-l border-border-default/60 pl-3 h-6 flex items-center">
-                  SATS
-                </span>
-              </div>
-              {currentCapacity > 0 && (
-                <div className="mt-4 px-1">
-                  <div className="relative">
-                    <div className="relative h-2 rounded-full bg-secondary/20 overflow-hidden">
-                      <div
-                        className="absolute left-0 top-0 h-full rounded-full bg-gradient-to-r from-primary/70 to-primary transition-all duration-200"
-                        style={{
-                          width: `${Math.max(0, Math.min(100, ((currentCapacity - effectiveMinCapacity) / Math.max(1, effectiveMaxCapacity - effectiveMinCapacity)) * 100))}%`,
-                        }}
-                      />
-                    </div>
-                    <input
-                      className="absolute inset-0 w-full opacity-0 cursor-pointer h-2"
-                      max={effectiveMaxCapacity}
-                      min={effectiveMinCapacity}
-                      onChange={(e) => handleCapacityChange(e.target.value)}
-                      step={1000}
-                      type="range"
-                      value={currentCapacity}
-                    />
-                    <div
-                      className="absolute top-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-white border-2 border-primary shadow-lg shadow-primary/30 pointer-events-none transition-all duration-200"
-                      style={{
-                        left: `calc(${Math.max(0, Math.min(100, ((currentCapacity - effectiveMinCapacity) / Math.max(1, effectiveMaxCapacity - effectiveMinCapacity)) * 100))}% - 8px)`,
-                      }}
-                    />
-                  </div>
-                  <div className="flex justify-between text-xs text-content-tertiary mt-3">
-                    <span>Min: {formatNumber(effectiveMinCapacity)} sats</span>
-                    <span>Max: {formatNumber(effectiveMaxCapacity)} sats</span>
-                  </div>
-                </div>
-              )}
             </div>
 
-            {/* Outbound Balance — how many sats are yours to send at open */}
-            <div className="mb-12">
-              <div className="flex items-center justify-between mb-2">
-                <div className="flex items-center gap-1.5">
-                  <label className="text-sm font-medium text-content-secondary">
-                    Outbound Balance
-                  </label>
-                  <InfoHint content="How many sats start on your side, ready to send the moment the channel opens. The rest is inbound — what you can receive." />
-                </div>
-                {maxOutbound > 0 && (
+            <div className="bg-surface-overlay/50 backdrop-blur-sm rounded-xl border border-border-default/50 p-8">
+              {/* Channel Capacity */}
+              <div className="mb-12">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-1.5">
+                    <label className="text-sm font-medium text-content-secondary">
+                      {t('orderChannel.step2.channelCapacity')}
+                    </label>
+                    <InfoHint content="The total size of the channel, in sats. A larger capacity lets you send and receive more, but costs more on-chain to open." />
+                  </div>
                   <div className="flex items-center gap-1">
-                    {[25, 50, 75, 100].map((pct) => (
+                    {[
+                      { label: '100k', value: 100_000 },
+                      { label: '250k', value: 250_000 },
+                      { label: '500k', value: 500_000 },
+                      { label: '1M', value: 1_000_000 },
+                    ].map(({ label, value }) => (
                       <button
-                        className="px-2 py-0.5 rounded text-xs font-semibold border bg-surface-high/40 border-border-default/40 text-content-secondary hover:text-white hover:border-border-default/70 transition-colors"
-                        key={pct}
-                        onClick={() => {
-                          const amount = Math.floor(maxOutbound * (pct / 100))
-                          setValue(
-                            'clientBalanceSat',
-                            Math.min(
-                              Math.max(amount, minOutbound),
-                              maxOutbound
-                            ).toString()
-                          )
-                        }}
+                        className={`px-2 py-0.5 rounded text-xs font-semibold border transition-colors ${
+                          value > effectiveMaxCapacity
+                            ? 'opacity-30 cursor-not-allowed bg-surface-high/40 border-border-default/40 text-content-secondary'
+                            : 'bg-surface-high/40 border-border-default/40 text-content-secondary hover:text-white hover:border-border-default/70'
+                        }`}
+                        disabled={value > effectiveMaxCapacity}
+                        key={label}
+                        onClick={() => handleCapacityChange(value.toString())}
                         type="button"
                       >
-                        {pct === 100 ? 'MAX' : `${pct}%`}
+                        {label}
                       </button>
                     ))}
                   </div>
-                )}
-              </div>
-              <LiquiditySlider
-                inboundColor="bg-emerald-500"
-                inboundLabel={`${formatNumber(Math.max(0, currentCapacity - btcOut))} sats`}
-                inputFocusClass="focus:border-primary"
-                inputHint="Type the exact BTC amount you want available to send once the channel is live."
-                inputLabel="Available to send now"
-                inputTextClass="text-white"
-                max={maxOutbound}
-                maxLabel={`Max: ${formatNumber(maxOutbound)} sats`}
-                min={minOutbound}
-                minLabel={`Min: ${formatNumber(minOutbound)} sats`}
-                onChange={(val) =>
-                  setValue('clientBalanceSat', Math.round(val).toString())
-                }
-                outboundColor="bg-[#9365FF]"
-                outboundLabel={`${formatNumber(btcOut)} sats`}
-                step={currentCapacity >= 1000000 ? 10000 : 1000}
-                thumbBorderClass="border-[#9365FF]"
-                unit="sats"
-                value={btcOut}
-              />
-            </div>
-
-            {/* Add RGB Asset */}
-            <div className="mb-12">
-              <h5 className="text-lg font-semibold text-white mb-3">
-                Add RGB Asset
-              </h5>
-
-              <div
-                className="flex flex-wrap items-center gap-2"
-                ref={assetDropdownRef}
-              >
-                {/* BTC-only (no RGB asset) */}
-                <button
-                  className={assetChipClass(!selectedAsset)}
-                  onClick={() => selectAsset(null)}
-                  type="button"
-                >
-                  {t('orderChannel.step2.noAsset')}
-                </button>
-
-                {/* First N assets as one-click chips */}
-                {visibleAssets.map((asset) => (
-                  <AssetChip
-                    asset={asset}
-                    isSelected={selectedAsset?.asset_id === asset.asset_id}
-                    key={asset.asset_id}
-                    onSelect={() => selectAsset(asset)}
+                </div>
+                <div className="relative">
+                  <input
+                    className="w-full pl-4 pr-20 py-2 bg-surface-base/50 rounded-lg border border-border-default/30 text-white text-2xl font-semibold focus:border-primary/60 focus:ring-2 focus:ring-primary/15 placeholder:text-content-tertiary/50 h-14 hover:border-border-default/50 focus:outline-none"
+                    onChange={(e) => handleCapacityChange(e.target.value)}
+                    placeholder="0"
+                    type="text"
+                    value={
+                      currentCapacity > 0 ? formatNumber(currentCapacity) : ''
+                    }
                   />
-                ))}
-
-                {/* Remaining assets collapsed into a compact dropdown */}
-                {overflowAssets.length > 0 && (
-                  <div className="relative">
-                    <button
-                      className={assetChipClass(
-                        isAssetDropdownOpen ||
-                          overflowAssets.some(
-                            (a) => a.asset_id === selectedAsset?.asset_id
-                          )
-                      )}
-                      onClick={() =>
-                        setIsAssetDropdownOpen(!isAssetDropdownOpen)
-                      }
-                      type="button"
-                    >
-                      {t('orderChannel.step2.moreAssets', {
-                        count: overflowAssets.length,
-                        defaultValue: '+{{count}} more',
-                      })}
-                      <ChevronDown
-                        className={`w-3.5 h-3.5 flex-shrink-0 transition-transform duration-200 ${isAssetDropdownOpen ? 'rotate-180' : ''}`}
-                      />
-                    </button>
-
-                    {isAssetDropdownOpen && (
-                      <div className="absolute z-50 mt-1 min-w-[220px] rounded-lg border border-border-default/50 bg-blue-darker shadow-xl overflow-hidden">
-                        <div className="max-h-[220px] overflow-y-auto">
-                          {overflowAssets.map((asset) => (
-                            <BuyAssetDropdownItem
-                              asset={asset}
-                              isSelected={
-                                selectedAsset?.asset_id === asset.asset_id
-                              }
-                              key={asset.asset_id}
-                              onSelect={() => selectAsset(asset)}
-                            />
-                          ))}
-                        </div>
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-content-tertiary/50 text-sm font-semibold pointer-events-none select-none tracking-wide border-l border-border-default/60 pl-3 h-6 flex items-center">
+                    SATS
+                  </span>
+                </div>
+                {currentCapacity > 0 && (
+                  <div className="mt-4 px-1">
+                    <div className="relative">
+                      <div className="relative h-2 rounded-full bg-secondary/20 overflow-hidden">
+                        <div
+                          className="absolute left-0 top-0 h-full rounded-full bg-gradient-to-r from-primary/70 to-primary transition-all duration-200"
+                          style={{
+                            width: `${Math.max(0, Math.min(100, ((currentCapacity - effectiveMinCapacity) / Math.max(1, effectiveMaxCapacity - effectiveMinCapacity)) * 100))}%`,
+                          }}
+                        />
                       </div>
-                    )}
+                      <input
+                        className="absolute inset-0 w-full opacity-0 cursor-pointer h-2"
+                        max={effectiveMaxCapacity}
+                        min={effectiveMinCapacity}
+                        onChange={(e) => handleCapacityChange(e.target.value)}
+                        step={1000}
+                        type="range"
+                        value={currentCapacity}
+                      />
+                      <div
+                        className="absolute top-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-white border-2 border-primary shadow-lg shadow-primary/30 pointer-events-none transition-all duration-200"
+                        style={{
+                          left: `calc(${Math.max(0, Math.min(100, ((currentCapacity - effectiveMinCapacity) / Math.max(1, effectiveMaxCapacity - effectiveMinCapacity)) * 100))}% - 8px)`,
+                        }}
+                      />
+                    </div>
+                    <div className="flex justify-between text-xs text-content-tertiary mt-3">
+                      <span>
+                        Min: {formatNumber(effectiveMinCapacity)} sats
+                      </span>
+                      <span>
+                        Max: {formatNumber(effectiveMaxCapacity)} sats
+                      </span>
+                    </div>
                   </div>
                 )}
               </div>
 
-              {selectedAsset && addAsset && assetInfo && (
-                <div className="mt-6">
-                  <div className="bg-surface-base/50 p-6 rounded-lg space-y-4">
-                    <div className="space-y-3">
-                      <div className="bg-surface-overlay/50 rounded-xl p-4 border border-border-default/50">
-                        <div className="flex items-center gap-3 mb-4 pb-3 border-b border-border-default/50">
-                          <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center border-2 border-border-default/50">
-                            <img
-                              alt={selectedAsset.ticker}
-                              className="w-5 h-5"
-                              onError={() => setSelectedAssetIcon(rgbIcon)}
-                              src={selectedAssetIcon}
-                            />
+              {/* Outbound Balance — how many sats are yours to send at open */}
+              <div className="mb-12">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-1.5">
+                    <label className="text-sm font-medium text-content-secondary">
+                      Outbound Balance
+                    </label>
+                    <InfoHint content="How many sats start on your side, ready to send the moment the channel opens. The rest is inbound — what you can receive." />
+                  </div>
+                  {maxOutbound > 0 && (
+                    <div className="flex items-center gap-1">
+                      {[25, 50, 75, 100].map((pct) => (
+                        <button
+                          className="px-2 py-0.5 rounded text-xs font-semibold border bg-surface-high/40 border-border-default/40 text-content-secondary hover:text-white hover:border-border-default/70 transition-colors"
+                          key={pct}
+                          onClick={() => {
+                            const amount = Math.floor(maxOutbound * (pct / 100))
+                            setValue(
+                              'clientBalanceSat',
+                              Math.min(
+                                Math.max(amount, minOutbound),
+                                maxOutbound
+                              ).toString()
+                            )
+                          }}
+                          type="button"
+                        >
+                          {pct === 100 ? 'MAX' : `${pct}%`}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <LiquiditySlider
+                  inboundColor="bg-emerald-500"
+                  inboundLabel={`${formatNumber(Math.max(0, currentCapacity - btcOut))} sats`}
+                  inputFocusClass="focus:border-primary"
+                  inputHint="Type the exact BTC amount you want available to send once the channel is live."
+                  inputLabel="Available to send now"
+                  inputTextClass="text-white"
+                  max={maxOutbound}
+                  maxLabel={`Max: ${formatNumber(maxOutbound)} sats`}
+                  min={minOutbound}
+                  minLabel={`Min: ${formatNumber(minOutbound)} sats`}
+                  onChange={(val) =>
+                    setValue('clientBalanceSat', Math.round(val).toString())
+                  }
+                  outboundColor="bg-[#9365FF]"
+                  outboundLabel={`${formatNumber(btcOut)} sats`}
+                  step={currentCapacity >= 1000000 ? 10000 : 1000}
+                  thumbBorderClass="border-[#9365FF]"
+                  unit="sats"
+                  value={btcOut}
+                />
+              </div>
+
+              {/* Add RGB Asset */}
+              <div className="mb-12">
+                <h5 className="text-lg font-semibold text-white mb-3">
+                  Add RGB Asset
+                </h5>
+
+                <div
+                  className="flex flex-wrap items-center gap-2"
+                  ref={assetDropdownRef}
+                >
+                  {/* BTC-only (no RGB asset) */}
+                  <button
+                    className={assetChipClass(!selectedAsset)}
+                    onClick={() => selectAsset(null)}
+                    type="button"
+                  >
+                    {t('orderChannel.step2.noAsset')}
+                  </button>
+
+                  {/* First N assets as one-click chips */}
+                  {visibleAssets.map((asset) => (
+                    <AssetChip
+                      asset={asset}
+                      isSelected={selectedAsset?.asset_id === asset.asset_id}
+                      key={asset.asset_id}
+                      onSelect={() => selectAsset(asset)}
+                    />
+                  ))}
+
+                  {/* Remaining assets collapsed into a compact dropdown */}
+                  {overflowAssets.length > 0 && (
+                    <div className="relative">
+                      <button
+                        className={assetChipClass(
+                          isAssetDropdownOpen ||
+                            overflowAssets.some(
+                              (a) => a.asset_id === selectedAsset?.asset_id
+                            )
+                        )}
+                        onClick={() =>
+                          setIsAssetDropdownOpen(!isAssetDropdownOpen)
+                        }
+                        type="button"
+                      >
+                        {t('orderChannel.step2.moreAssets', {
+                          count: overflowAssets.length,
+                          defaultValue: '+{{count}} more',
+                        })}
+                        <ChevronDown
+                          className={`w-3.5 h-3.5 flex-shrink-0 transition-transform duration-200 ${isAssetDropdownOpen ? 'rotate-180' : ''}`}
+                        />
+                      </button>
+
+                      {isAssetDropdownOpen && (
+                        <div className="absolute z-50 mt-1 min-w-[220px] rounded-lg border border-border-default/50 bg-blue-darker shadow-xl overflow-hidden">
+                          <div className="max-h-[220px] overflow-y-auto">
+                            {overflowAssets.map((asset) => (
+                              <BuyAssetDropdownItem
+                                asset={asset}
+                                isSelected={
+                                  selectedAsset?.asset_id === asset.asset_id
+                                }
+                                key={asset.asset_id}
+                                onSelect={() => selectAsset(asset)}
+                              />
+                            ))}
                           </div>
-                          <div className="flex-1">
-                            <div className="flex items-center gap-2">
-                              <span className="text-lg font-semibold text-white">
-                                {selectedAsset.ticker}
-                              </span>
-                              <span className="text-sm text-content-secondary">
-                                ({selectedAsset.name})
-                              </span>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                {selectedAsset && addAsset && assetInfo && (
+                  <div className="mt-6">
+                    <div className="bg-surface-base/50 p-6 rounded-lg space-y-4">
+                      <div className="space-y-3">
+                        <div className="bg-surface-overlay/50 rounded-xl p-4 border border-border-default/50">
+                          <div className="flex items-center gap-3 mb-4 pb-3 border-b border-border-default/50">
+                            <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center border-2 border-border-default/50">
+                              <img
+                                alt={selectedAsset.ticker}
+                                className="w-5 h-5"
+                                onError={() => setSelectedAssetIcon(rgbIcon)}
+                                src={selectedAssetIcon}
+                              />
+                            </div>
+                            <div className="flex-1">
+                              <div className="flex items-center gap-2">
+                                <span className="text-lg font-semibold text-white">
+                                  {selectedAsset.ticker}
+                                </span>
+                                <span className="text-sm text-content-secondary">
+                                  ({selectedAsset.name})
+                                </span>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                        <div className="text-xs text-content-tertiary font-mono truncate">
-                          {selectedAsset.asset_id}
-                        </div>
-                      </div>
-
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-1.5">
-                            <label className="text-sm font-medium text-content-secondary">
-                              Amount
-                            </label>
-                            <InfoHint content="Total amount of this asset the channel will hold. Set how much starts on your side below — that portion is what you're buying." />
+                          <div className="text-xs text-content-tertiary font-mono truncate">
+                            {selectedAsset.asset_id}
                           </div>
-                          {assetPresetsCalc.length > 0 && (
-                            <div className="flex items-center gap-1">
-                              {assetPresetsCalc.map((preset) => (
-                                <button
-                                  className={`px-2 py-0.5 rounded text-xs font-semibold border transition-colors ${
-                                    Math.abs(
-                                      parseFloat(lspAssetAmount || '0') - preset
-                                    ) < 0.001
-                                      ? 'bg-primary/10 border-primary text-primary'
-                                      : 'bg-surface-high/40 border-border-default/40 text-content-secondary hover:text-white hover:border-border-default/70'
-                                  }`}
-                                  key={preset}
-                                  onClick={() =>
-                                    setValue(
-                                      'lspAssetAmount',
-                                      preset.toString()
-                                    )
-                                  }
-                                  type="button"
-                                >
-                                  {preset}
-                                </button>
-                              ))}
-                            </div>
-                          )}
                         </div>
 
-                        <div className="relative">
-                          <input
-                            className="w-full pl-4 pr-20 py-2 bg-surface-base/50 rounded-lg border border-border-default/30 text-white text-2xl font-semibold focus:border-primary/60 focus:ring-2 focus:ring-primary/15 placeholder:text-content-tertiary/50 h-14 hover:border-border-default/50 focus:outline-none"
-                            onChange={(e) => {
-                              const val = e.target.value
-                              if (val === '' || /^[\d.]*$/.test(val)) {
-                                const re =
-                                  assetInfo.precision > 0
-                                    ? new RegExp(
-                                        `^\\d*\\.?\\d{0,${assetInfo.precision}}$`
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-1.5">
+                              <label className="text-sm font-medium text-content-secondary">
+                                Amount
+                              </label>
+                              <InfoHint content="Total amount of this asset the channel will hold. Set how much starts on your side below — that portion is what you're buying." />
+                            </div>
+                            {assetPresetsCalc.length > 0 && (
+                              <div className="flex items-center gap-1">
+                                {assetPresetsCalc.map((preset) => (
+                                  <button
+                                    className={`px-2 py-0.5 rounded text-xs font-semibold border transition-colors ${
+                                      Math.abs(
+                                        parseFloat(lspAssetAmount || '0') -
+                                          preset
+                                      ) < 0.001
+                                        ? 'bg-primary/10 border-primary text-primary'
+                                        : 'bg-surface-high/40 border-border-default/40 text-content-secondary hover:text-white hover:border-border-default/70'
+                                    }`}
+                                    key={preset}
+                                    onClick={() =>
+                                      setValue(
+                                        'lspAssetAmount',
+                                        preset.toString()
                                       )
-                                    : /^\d*$/
-                                if (re.test(val))
-                                  setValue('lspAssetAmount', val)
-                              }
-                            }}
-                            placeholder="0"
-                            type="text"
-                            value={lspAssetAmount}
-                          />
-                          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-content-tertiary/60 text-sm font-semibold pointer-events-none select-none tracking-wide">
-                            {selectedAsset.ticker}
-                          </span>
-                        </div>
+                                    }
+                                    type="button"
+                                  >
+                                    {preset}
+                                  </button>
+                                ))}
+                              </div>
+                            )}
+                          </div>
 
-                        {/* Channel Capacity slider — synced with lspAssetAmount input above, shown only when value > 0 */}
-                        {parseFloat(lspAssetAmount || '0') > 0 &&
-                          assetMax > assetMin && (
-                            <div className="mt-4 px-1">
-                              <div className="relative">
-                                <div className="relative h-2 rounded-full bg-secondary/20 overflow-hidden">
+                          <div className="relative">
+                            <input
+                              className="w-full pl-4 pr-20 py-2 bg-surface-base/50 rounded-lg border border-border-default/30 text-white text-2xl font-semibold focus:border-primary/60 focus:ring-2 focus:ring-primary/15 placeholder:text-content-tertiary/50 h-14 hover:border-border-default/50 focus:outline-none"
+                              onChange={(e) => {
+                                const val = e.target.value
+                                if (val === '' || /^[\d.]*$/.test(val)) {
+                                  const re =
+                                    assetInfo.precision > 0
+                                      ? new RegExp(
+                                          `^\\d*\\.?\\d{0,${assetInfo.precision}}$`
+                                        )
+                                      : /^\d*$/
+                                  if (re.test(val))
+                                    setValue('lspAssetAmount', val)
+                                }
+                              }}
+                              placeholder="0"
+                              type="text"
+                              value={lspAssetAmount}
+                            />
+                            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-content-tertiary/60 text-sm font-semibold pointer-events-none select-none tracking-wide">
+                              {selectedAsset.ticker}
+                            </span>
+                          </div>
+
+                          {/* Channel Capacity slider — synced with lspAssetAmount input above, shown only when value > 0 */}
+                          {parseFloat(lspAssetAmount || '0') > 0 &&
+                            assetMax > assetMin && (
+                              <div className="mt-4 px-1">
+                                <div className="relative">
+                                  <div className="relative h-2 rounded-full bg-secondary/20 overflow-hidden">
+                                    <div
+                                      className="absolute left-0 top-0 h-full rounded-full bg-gradient-to-r from-primary/70 to-primary transition-all duration-200"
+                                      style={{
+                                        width: `${Math.max(0, Math.min(100, ((parseFloat(lspAssetAmount || '0') - assetMin) / (assetMax - assetMin)) * 100))}%`,
+                                      }}
+                                    />
+                                  </div>
+                                  <input
+                                    className="absolute inset-0 w-full opacity-0 cursor-pointer h-2"
+                                    max={assetMax}
+                                    min={assetMin}
+                                    onChange={(e) =>
+                                      setValue('lspAssetAmount', e.target.value)
+                                    }
+                                    step={Math.max(
+                                      1,
+                                      (assetMax - assetMin) / 100
+                                    )}
+                                    type="range"
+                                    value={parseFloat(lspAssetAmount || '0')}
+                                  />
                                   <div
-                                    className="absolute left-0 top-0 h-full rounded-full bg-gradient-to-r from-primary/70 to-primary transition-all duration-200"
+                                    className="absolute top-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-white border-2 border-primary shadow-lg shadow-primary/30 pointer-events-none transition-all duration-200"
                                     style={{
-                                      width: `${Math.max(0, Math.min(100, ((parseFloat(lspAssetAmount || '0') - assetMin) / (assetMax - assetMin)) * 100))}%`,
+                                      left: `calc(${Math.max(0, Math.min(100, ((parseFloat(lspAssetAmount || '0') - assetMin) / (assetMax - assetMin)) * 100))}% - 8px)`,
                                     }}
                                   />
                                 </div>
-                                <input
-                                  className="absolute inset-0 w-full opacity-0 cursor-pointer h-2"
-                                  max={assetMax}
-                                  min={assetMin}
-                                  onChange={(e) =>
-                                    setValue('lspAssetAmount', e.target.value)
-                                  }
-                                  step={Math.max(
-                                    1,
-                                    (assetMax - assetMin) / 100
-                                  )}
-                                  type="range"
-                                  value={parseFloat(lspAssetAmount || '0')}
-                                />
-                                <div
-                                  className="absolute top-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-white border-2 border-primary shadow-lg shadow-primary/30 pointer-events-none transition-all duration-200"
-                                  style={{
-                                    left: `calc(${Math.max(0, Math.min(100, ((parseFloat(lspAssetAmount || '0') - assetMin) / (assetMax - assetMin)) * 100))}% - 8px)`,
-                                  }}
-                                />
+                                <div className="flex justify-between text-xs text-content-tertiary mt-2">
+                                  <span>
+                                    Min: {assetMin} {selectedAsset.ticker}
+                                  </span>
+                                  <span>
+                                    Max: {assetMax} {selectedAsset.ticker}
+                                  </span>
+                                </div>
                               </div>
-                              <div className="flex justify-between text-xs text-content-tertiary mt-2">
-                                <span>
-                                  Min: {assetMin} {selectedAsset.ticker}
-                                </span>
-                                <span>
-                                  Max: {assetMax} {selectedAsset.ticker}
-                                </span>
-                              </div>
+                            )}
+
+                          {/* Outbound Balance — how much of the asset is yours to send at open (drives the quote) */}
+                          {parseFloat(lspAssetAmount || '0') > 0 && (
+                            <div className="mt-4">
+                              <LiquiditySlider
+                                inboundColor="bg-emerald-500"
+                                inboundLabel={`${Math.max(0, (parseFloat(lspAssetAmount) || 0) - (parseFloat(clientAssetAmount) || 0)).toFixed(assetInfo.precision > 0 ? 2 : 0)} ${selectedAsset.ticker}`}
+                                inputFocusClass="focus:border-primary"
+                                inputHint={`Type the exact ${selectedAsset.ticker} amount you want available to send immediately after funding.`}
+                                inputLabel="Available to send now"
+                                inputTextClass="text-white"
+                                max={parseFloat(lspAssetAmount) || 0}
+                                maxLabel={`Max: ${parseFloat(lspAssetAmount) || 0} ${selectedAsset.ticker}`}
+                                min={0}
+                                minLabel={`0 ${selectedAsset.ticker}`}
+                                onChange={(val) =>
+                                  setValue('clientAssetAmount', val.toString())
+                                }
+                                outboundColor="bg-[#9365FF]"
+                                outboundLabel={`${(parseFloat(clientAssetAmount) || 0).toFixed(assetInfo.precision > 0 ? 2 : 0)} ${selectedAsset.ticker}`}
+                                step={
+                                  (parseFloat(lspAssetAmount) || 0) >= 1000
+                                    ? 10
+                                    : assetInfo.precision > 0
+                                      ? 1 / assetFactor
+                                      : 1
+                                }
+                                thumbBorderClass="border-[#9365FF]"
+                                unit={selectedAsset.ticker}
+                                value={parseFloat(clientAssetAmount) || 0}
+                              />
                             </div>
                           )}
 
-                        {/* Outbound Balance — how much of the asset is yours to send at open (drives the quote) */}
-                        {parseFloat(lspAssetAmount || '0') > 0 && (
-                          <div className="mt-4">
-                            <LiquiditySlider
-                              inboundColor="bg-emerald-500"
-                              inboundLabel={`${Math.max(0, (parseFloat(lspAssetAmount) || 0) - (parseFloat(clientAssetAmount) || 0)).toFixed(assetInfo.precision > 0 ? 2 : 0)} ${selectedAsset.ticker}`}
-                              inputFocusClass="focus:border-primary"
-                              inputHint={`Type the exact ${selectedAsset.ticker} amount you want available to send immediately after funding.`}
-                              inputLabel="Available to send now"
-                              inputTextClass="text-white"
-                              max={parseFloat(lspAssetAmount) || 0}
-                              maxLabel={`Max: ${parseFloat(lspAssetAmount) || 0} ${selectedAsset.ticker}`}
-                              min={0}
-                              minLabel={`0 ${selectedAsset.ticker}`}
-                              onChange={(val) =>
-                                setValue('clientAssetAmount', val.toString())
-                              }
-                              outboundColor="bg-[#9365FF]"
-                              outboundLabel={`${(parseFloat(clientAssetAmount) || 0).toFixed(assetInfo.precision > 0 ? 2 : 0)} ${selectedAsset.ticker}`}
-                              step={
-                                (parseFloat(lspAssetAmount) || 0) >= 1000
-                                  ? 10
-                                  : assetInfo.precision > 0
-                                    ? 1 / assetFactor
-                                    : 1
-                              }
-                              thumbBorderClass="border-[#9365FF]"
-                              unit={selectedAsset.ticker}
-                              value={parseFloat(clientAssetAmount) || 0}
-                            />
-                          </div>
-                        )}
-
-                        {clientAssetAmount &&
-                          parseFloat(clientAssetAmount) > 0 && (
-                            <AssetQuoteDisplay
-                              assetInfo={assetInfo}
-                              quote={quote}
-                              quoteError={quoteError}
-                              quoteLoading={quoteLoading}
-                            />
-                          )}
+                          {clientAssetAmount &&
+                            parseFloat(clientAssetAmount) > 0 && (
+                              <AssetQuoteDisplay
+                                assetInfo={assetInfo}
+                                quote={quote}
+                                quoteError={quoteError}
+                                quoteLoading={quoteLoading}
+                              />
+                            )}
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
+                )}
+              </div>
+
+              {/* Channel Duration */}
+              <div className="mb-12">
+                <ChannelDurationSelector
+                  containerClassName="border-0 p-0"
+                  control={control}
+                  maxExpiryBlocks={lspOptions?.max_channel_expiry_blocks}
+                  onChange={(value) => setValue('channelExpireBlocks', value)}
+                  theme="dark"
+                  value={channelExpireBlocks}
+                />
+              </div>
+
+              {/* Fee breakdown — mirror the old Buy Channel modal: show the LSP
+                fees, the liquidity you're funding, any asset purchase, and the
+                aggregated total the user will actually pay. */}
+              {(fees || isLoadingFees) && (
+                <FeeBreakdownDisplay
+                  additionalCosts={[
+                    {
+                      amount: btcOut,
+                      label: t('components.buyChannelModal.yourLiquidity'),
+                    },
+                    ...(quote &&
+                    clientAssetAmount &&
+                    parseFloat(clientAssetAmount) > 0
+                      ? [
+                          {
+                            amount: getQuoteFromAmount(quote) / 1000,
+                            className: 'text-primary font-medium',
+                            label: t(
+                              'components.buyChannelModal.assetPurchase'
+                            ),
+                          },
+                        ]
+                      : []),
+                  ]}
+                  containerClassName="bg-surface-base/50 border border-border-default/30 rounded-xl p-4"
+                  fees={fees}
+                  isLoading={isLoadingFees}
+                  showGrandTotal
+                />
               )}
             </div>
-
-            {/* Channel Duration */}
-            <div className="mb-12">
-              <ChannelDurationSelector
-                containerClassName="border-0 p-0"
-                control={control}
-                maxExpiryBlocks={lspOptions?.max_channel_expiry_blocks}
-                onChange={(value) => setValue('channelExpireBlocks', value)}
-                theme="dark"
-                value={channelExpireBlocks}
-              />
-            </div>
-
-            {/* Fee breakdown */}
-            {(fees || isLoadingFees) && (
-              <FeeBreakdownDisplay
-                additionalCosts={[
-                  ...(quote &&
-                  clientAssetAmount &&
-                  parseFloat(clientAssetAmount) > 0
-                    ? [
-                        {
-                          amount: getQuoteFromAmount(quote) / 1000,
-                          className: 'text-primary font-medium',
-                          label: t('components.buyChannelModal.assetPurchase'),
-                        },
-                      ]
-                    : []),
-                ]}
-                containerClassName="bg-surface-base/50 border border-border-default/30 rounded-xl p-4"
-                fees={fees}
-                isLoading={isLoadingFees}
-              />
-            )}
-          </div>
+          </>
         )}
 
         {/* Actions */}

--- a/src/routes/order-new-channel/Step3.tsx
+++ b/src/routes/order-new-channel/Step3.tsx
@@ -7,6 +7,7 @@ import {
   Copy,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { ClipLoader } from 'react-spinners'
 import { toast } from 'react-toastify'
 import CopyToClipboard from 'react-copy-to-clipboard'
 
@@ -79,10 +80,13 @@ export const Step3: React.FC<Props> = ({
 
   if (!order) {
     return (
-      <div className="max-w-lg mx-auto flex justify-center items-center h-64">
-        <span className="text-content-secondary">
-          {t('orderChannel.step3.loadingOrder')}
-        </span>
+      <div className="max-w-lg mx-auto flex min-h-[40vh] items-center justify-center">
+        <div className="flex items-center gap-4 rounded-xl border border-border-default/50 bg-surface-overlay/50 px-8 py-6 backdrop-blur-sm">
+          <ClipLoader color="#15E99A" loading size={32} />
+          <span className="text-content-secondary">
+            {t('orderChannel.step3.loadingOrder')}
+          </span>
+        </div>
       </div>
     )
   }

--- a/src/routes/order-new-channel/components/WalletConfirmationModal.tsx
+++ b/src/routes/order-new-channel/components/WalletConfirmationModal.tsx
@@ -8,7 +8,7 @@ import {
   X,
   Zap,
 } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
@@ -84,6 +84,44 @@ export const WalletConfirmationModal: React.FC<
   const [selectedMethod, setSelectedMethod] = useState<
     'lightning' | 'onchain' | null
   >(null)
+  // Whether the user has explicitly picked a method — once they have, we stop
+  // overriding their choice with the auto-default.
+  const [hasUserSelected, setHasUserSelected] = useState(false)
+
+  // Pre-select a sensible default when the modal opens: prefer Lightning, but
+  // fall back to whichever method the user can actually afford (a brand-new
+  // node has no outbound liquidity yet, so on-chain is often the only payable
+  // option). Re-evaluated as balances load, until the user picks manually.
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedMethod(null)
+      setHasUserSelected(false)
+      return
+    }
+    if (hasUserSelected) return
+    const lnAvailable = lightningAmountSat > 0
+    const chainAvailable = onchainAmountSat > 0
+    const lnAffordable = outboundLiquidity >= lightningAmountSat
+    const chainAffordable = onChainBalance >= onchainAmountSat
+    const preferred =
+      lnAvailable && lnAffordable
+        ? 'lightning'
+        : chainAvailable && chainAffordable
+          ? 'onchain'
+          : lnAvailable
+            ? 'lightning'
+            : chainAvailable
+              ? 'onchain'
+              : null
+    setSelectedMethod(preferred)
+  }, [
+    isOpen,
+    hasUserSelected,
+    lightningAmountSat,
+    onchainAmountSat,
+    outboundLiquidity,
+    onChainBalance,
+  ])
 
   if (!isOpen) return null
   if (typeof document === 'undefined') return null
@@ -103,6 +141,7 @@ export const WalletConfirmationModal: React.FC<
         : false
 
   const handleCardClick = (method: 'lightning' | 'onchain') => {
+    setHasUserSelected(true)
     setSelectedMethod((prev) => (prev === method ? null : method))
   }
 

--- a/src/routes/order-new-channel/index.tsx
+++ b/src/routes/order-new-channel/index.tsx
@@ -647,8 +647,16 @@ export const Component = () => {
           </div>
         )}
         {loading && (
-          <div className="absolute inset-0 flex justify-center items-center bg-black bg-opacity-50 z-50">
+          <div className="absolute inset-0 z-50 flex min-h-[60vh] flex-col items-center justify-center gap-4 bg-surface-base/85 backdrop-blur-sm">
             <Spinner color="#15E99A" overlay={false} size={50} />
+            <div className="text-center">
+              <p className="text-base font-semibold text-white">
+                {t('orderChannel.creatingOrder')}
+              </p>
+              <p className="mt-1 text-sm text-content-secondary">
+                {t('orderChannel.creatingOrderHint')}
+              </p>
+            </div>
           </div>
         )}
         {showBackConfirmation && <BackConfirmationModal />}

--- a/src/routes/wallet-dashboard/index.tsx
+++ b/src/routes/wallet-dashboard/index.tsx
@@ -217,11 +217,19 @@ export const Component = () => {
     0
   )
 
+  // Treat the pre-trigger (uninitialized) window as loading too. These are lazy
+  // queries, so on first mount — before refreshData() fires them — RTK reports
+  // isLoading=false with no data yet. Without this the balance would flash "0"
+  // before the first fetch resolves; we want a loading placeholder instead.
   const isLoading =
+    btcBalanceResponse.isUninitialized ||
+    listChannelsResponse.isUninitialized ||
     (btcBalanceResponse.isLoading && !btcBalanceResponse.data) ||
     (listChannelsResponse.isLoading && !listChannelsResponse.data)
 
-  const isAssetsLoading = assetsResponse.isLoading && !assetsResponse.data
+  const isAssetsLoading =
+    assetsResponse.isUninitialized ||
+    (assetsResponse.isLoading && !assetsResponse.data)
 
   const liquidityTotal = totalInboundLiquidity + totalOutboundLiquidity
   const outboundPct =

--- a/src/routes/wallet-remote/index.tsx
+++ b/src/routes/wallet-remote/index.tsx
@@ -690,7 +690,7 @@ export const Component = () => {
                       icon={<BookOpen className="w-4 h-4" />}
                       onClick={() =>
                         openUrl(
-                          'https://docs.kaleidoswap.com/setup/remote-node'
+                          'https://docs.kaleidoswap.com/desktop-app/getting-started/node-hosting'
                         )
                       }
                       size="sm"


### PR DESCRIPTION
Conflict-free promotion of `dev` to `main` for the **v0.5.0 retag**. This branch is a single commit whose tree is identical to `dev` and whose parent is the current `main`, so it fast-forwards cleanly (supersedes #152, which conflicted due to the squash-merge history divergence).

## Changes since the last dev→main promotion (#151)
- Buy-a-channel step 2: aggregated cost / fee-breakdown grand total, step-2 guidance, branded order-creation loading (no black page)
- Payment: pre-selects a method, preferring Lightning
- Dashboard: loading placeholder instead of flashing `0`
- Node: user-facing "Reconnect node" button (shared `useNodeReconnect` hook)
- Docs: fixed broken documentation links
- Plus small post-#151 dev commits (Korean translation, order-channel LSP fix, market-maker onchain balance, README)

Net delta: ~12 files, matching the `main..dev` content diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)