### PR TITLE
style(ui): general UI polish — modals, buttons, icons, notifications

### DIFF
--- a/src/components/ChannelCard/index.tsx
+++ b/src/components/ChannelCard/index.tsx
@@ -374,7 +374,13 @@ export const ChannelCard: React.FC<ChannelCardProps> = ({
 
             {/* RGB badge */}
             {isRgbChannel && asset && (
-              <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded-full bg-purple-900/30 text-purple-300 border border-purple-800/30">
+              <span
+                className={`flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded-full ${
+                  asset.ticker === 'USDT'
+                    ? 'bg-[#26A17B]/10 text-[#26A17B] border border-[#26A17B]/30'
+                    : 'bg-purple-900/30 text-purple-300 border border-purple-800/30'
+                }`}
+              >
                 <AssetIcon className="h-2.5 w-2.5" ticker={asset.ticker} />
                 {asset.ticker}
               </span>
@@ -455,36 +461,42 @@ export const ChannelCard: React.FC<ChannelCardProps> = ({
             const inPct = total > 0 ? (inb / total) * 100 : 50
             return (
               <div className="rounded-lg bg-surface-overlay/40 p-2.5 border border-purple-800/20">
-                {/* Section header: asset + amounts */}
-                <div className="flex items-center justify-between gap-2 mb-1.5">
-                  <div className="flex items-center gap-1.5 text-[11px] text-lime-300/90">
+                {/* Section header: outbound | logo+ticker | inbound */}
+                <div className="grid grid-cols-3 items-center mb-1.5">
+                  <span className="flex items-center gap-0.5 text-[10px] font-mono text-[#9365FF]">
+                    <ArrowUpRight className="h-3 w-3" />
+                    {formatAssetAmount(out)}
+                  </span>
+                  <span
+                    className="flex items-center justify-center gap-1 text-[11px] font-semibold"
+                    style={asset.ticker === 'USDT' ? { color: '#26A17B' } : {}}
+                  >
                     <AssetIcon className="h-3.5 w-3.5" ticker={asset.ticker} />
-                    <span className="font-semibold">{asset.ticker}</span>
-                  </div>
-                  <div className="flex items-center gap-1.5 text-[10px] font-mono">
-                    <span className="flex items-center gap-0.5 text-lime-300">
-                      <ArrowUpRight className="h-3 w-3" />
-                      {formatAssetAmount(out)}
+                    <span
+                      className={
+                        asset.ticker === 'USDT' ? '' : 'text-content-secondary'
+                      }
+                    >
+                      {asset.ticker}
                     </span>
-                    <span className="text-content-tertiary/40">/</span>
-                    <span className="flex items-center gap-0.5 text-emerald-400">
-                      <ArrowDownRight className="h-3 w-3" />
-                      {formatAssetAmount(inb)}
-                    </span>
-                  </div>
+                  </span>
+                  <span className="flex items-center justify-end gap-0.5 text-[10px] font-mono text-emerald-400">
+                    {formatAssetAmount(inb)}
+                    <ArrowDownRight className="h-3 w-3" />
+                  </span>
                 </div>
                 <div className="relative h-2.5 bg-surface-overlay rounded-full overflow-hidden">
                   <div
-                    className="absolute left-0 top-0 h-full bg-lime-300 rounded-l-full"
+                    className="absolute left-0 top-0 h-full bg-[#9365FF] rounded-l-full"
                     style={{ width: `${outPct}%` }}
                   />
                   <div
-                    className="absolute right-0 top-0 h-full bg-emerald-600 rounded-r-full"
+                    className="absolute right-0 top-0 h-full bg-emerald-500 rounded-r-full"
                     style={{ width: `${inPct}%` }}
                   />
                 </div>
                 <div className="flex justify-between text-[8px] font-semibold uppercase tracking-wider mt-1">
-                  <span className="text-lime-300/70">
+                  <span className="text-[#9365FF]/70">
                     {t('channelCard.labels.outbound')}
                   </span>
                   <span className="text-emerald-400/70">

--- a/src/components/IssueAssetModal/index.tsx
+++ b/src/components/IssueAssetModal/index.tsx
@@ -1,16 +1,12 @@
-import { X } from 'lucide-react'
+import { Plus, Loader, Info, X } from 'lucide-react'
 import React, { useState, useMemo } from 'react'
-import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'react-toastify'
 
-import {
-  getModalPortalTarget,
-  getModalPositionClass,
-} from '../../helpers/modalPortal'
 import { useUtxoErrorHandler } from '../../hooks/useUtxoErrorHandler'
 import { nodeApi } from '../../slices/nodeApi/nodeApi.slice'
 import { CreateUTXOModal } from '../CreateUTXOModal'
+import { Modal } from '../ui/Modal'
 
 interface IssueAssetModalProps {
   onClose: () => void
@@ -33,34 +29,22 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
 
   const [issueAsset] = nodeApi.endpoints.issueNiaAsset.useMutation()
 
-  // Calculate the actual amount that will be issued with decimal places
   const actualAmount = useMemo(() => {
     if (
       !amount ||
       isNaN(Number(amount)) ||
       !precision ||
       isNaN(Number(precision))
-    ) {
+    )
       return '0'
-    }
-
-    // Convert to base units (add zeros based on precision)
-    const baseAmount = Number(amount) * Math.pow(10, Number(precision))
-    return baseAmount.toString()
+    return (Number(amount) * Math.pow(10, Number(precision))).toString()
   }, [amount, precision])
 
-  // Format preview amount with decimal places
   const previewAmount = useMemo(() => {
-    if (!amount || isNaN(Number(amount))) {
-      return '0'
-    }
-
-    // Clamp precision between 0 and 10
+    if (!amount || isNaN(Number(amount))) return '0'
     let safePrecision = Number(precision)
     if (isNaN(safePrecision) || safePrecision < 0) safePrecision = 0
     if (safePrecision > 10) safePrecision = 10
-
-    // Display with appropriate decimal places
     return Number(amount).toFixed(safePrecision)
   }, [amount, precision])
 
@@ -76,22 +60,18 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
-
     try {
       await issueAssetOperation()
       toast.success(t('issueAssetModal.success'))
       onSuccess()
       onClose()
     } catch (error: any) {
-      // Check if it's a UTXO-related error
       const wasHandled = handleApiError(
         error,
         'issuance',
         0,
         issueAssetOperation
       )
-
-      // Only show toast for errors that weren't handled by the UTXO modal
       if (!wasHandled) {
         toast.error(
           error?.data?.error ||
@@ -105,32 +85,36 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
     }
   }
 
-  const pos = getModalPositionClass()
+  const inputClass =
+    'w-full bg-surface-overlay/50 text-white px-4 py-2.5 rounded-lg border border-border-default ' +
+    'focus:border-primary/50 focus:ring-1 focus:ring-primary/20 focus:outline-none text-sm placeholder-content-tertiary'
 
-  return createPortal(
+  return (
     <>
-      <div
-        className={`${pos} inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50`}
-        onClick={onClose}
-      >
-        <div
-          className="bg-surface-overlay rounded-xl border border-border-default p-6 w-full max-w-md"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div className="flex justify-between items-center mb-6">
-            <h2 className="text-xl font-bold text-white">
+      <Modal isOpen onClose={onClose} size="sm">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-divider/10">
+          <div className="flex items-center gap-3">
+            <Plus className="w-5 h-5 text-primary" />
+            <h3 className="text-xl font-semibold text-white">
               {t('issueAssetModal.title')}
-            </h2>
-            <button
-              className="p-2 hover:bg-surface-high rounded-lg transition-colors"
-              onClick={onClose}
-            >
-              <X className="w-5 h-5 text-content-secondary" />
-            </button>
+            </h3>
           </div>
+          <button
+            aria-label="Close modal"
+            className="p-2 rounded-full hover:bg-surface-overlay text-content-secondary hover:text-white transition-colors"
+            onClick={onClose}
+          >
+            <X size={20} />
+          </button>
+        </div>
 
-          <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4 mb-6">
-            <p className="text-blue-400 text-sm">{t('issueAssetModal.note')}</p>
+        {/* Body */}
+        <div className="p-6 space-y-5">
+          {/* Info banner */}
+          <div className="flex items-start gap-3 rounded-lg bg-blue-500/10 border border-blue-500/20 p-4">
+            <Info className="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-blue-300">{t('issueAssetModal.note')}</p>
           </div>
 
           <form className="space-y-4" onSubmit={handleSubmit}>
@@ -139,7 +123,7 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
                 {t('issueAssetModal.tickerLabel')}
               </label>
               <input
-                className="w-full bg-surface-base border border-border-default rounded-lg px-4 py-2 text-white"
+                className={inputClass}
                 maxLength={5}
                 onChange={(e) => setTicker(e.target.value.toUpperCase())}
                 placeholder={t('issueAssetModal.tickerPlaceholder')}
@@ -154,7 +138,7 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
                 {t('issueAssetModal.nameLabel')}
               </label>
               <input
-                className="w-full bg-surface-base border border-border-default rounded-lg px-4 py-2 text-white"
+                className={inputClass}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={t('issueAssetModal.namePlaceholder')}
                 required
@@ -168,7 +152,7 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
                 {t('issueAssetModal.amountLabel')}
               </label>
               <input
-                className="w-full bg-surface-base border border-border-default rounded-lg px-4 py-2 text-white"
+                className={inputClass}
                 min="0"
                 onChange={(e) => setAmount(e.target.value)}
                 placeholder={t('issueAssetModal.amountPlaceholder')}
@@ -183,13 +167,11 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
                 {t('issueAssetModal.precisionLabel')}
               </label>
               <input
-                className="w-full bg-surface-base border border-border-default rounded-lg px-4 py-2 text-white"
+                className={inputClass}
                 max="18"
                 min="0"
                 onChange={(e) => {
-                  // removing fraction inputs
-                  const val = e.target.value
-                  const floored = Math.floor(Number(val))
+                  const floored = Math.floor(Number(e.target.value))
                   setPrecision(String(floored))
                 }}
                 placeholder={t('issueAssetModal.precisionPlaceholder')}
@@ -207,27 +189,32 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
             </div>
 
             {amount && (
-              <p className="mt-2 text-sm text-content-secondary">
+              <p className="text-sm text-content-secondary">
                 {t('issueAssetModal.previewPrefix')}{' '}
                 <span className="text-white font-medium">{previewAmount}</span>
               </p>
             )}
+
             <button
-              className="w-full px-6 py-3 bg-primary hover:bg-primary-emphasis
-                       text-primary-foreground rounded-lg font-medium transition-colors
-                       disabled:opacity-60 disabled:cursor-not-allowed"
+              className="w-full px-4 py-2.5 bg-primary hover:bg-primary-emphasis
+                       text-primary-foreground rounded-lg text-sm font-semibold transition-colors
+                       disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               disabled={isLoading}
               type="submit"
             >
+              {isLoading ? (
+                <Loader className="w-4 h-4 animate-spin" />
+              ) : (
+                <Plus className="w-4 h-4" />
+              )}
               {isLoading
                 ? t('issueAssetModal.submitting')
                 : t('issueAssetModal.submit')}
             </button>
           </form>
         </div>
-      </div>
+      </Modal>
 
-      {/* UTXO Modal for handling UTXO-related errors */}
       <CreateUTXOModal
         channelCapacity={utxoModalProps.channelCapacity}
         error={utxoModalProps.error}
@@ -237,7 +224,6 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
         operationType={utxoModalProps.operationType}
         retryFunction={utxoModalProps.retryFunction}
       />
-    </>,
-    getModalPortalTarget()
+    </>
   )
 }

--- a/src/components/Layout/Modal/Deposit/Step2.tsx
+++ b/src/components/Layout/Modal/Deposit/Step2.tsx
@@ -146,6 +146,12 @@ export const Step2 = ({ assetId, onBack, onClose, onNext }: Props) => {
     }
   }, [isBtc])
 
+  // Auto-generate address on mount for non-BTC flows
+  useEffect(() => {
+    if (isBtc) return
+    generateAddress()
+  }, [])
+
   // When BTC amount changes, regenerate LN invoice with new amount
   useEffect(() => {
     if (!isBtc) return
@@ -1235,17 +1241,13 @@ export const Step2 = ({ assetId, onBack, onClose, onNext }: Props) => {
             className="px-4 py-2 bg-primary hover:bg-primary-emphasis disabled:opacity-50 disabled:cursor-not-allowed
                      text-primary-foreground rounded-lg transition-colors flex items-center gap-1.5 text-sm font-semibold"
             disabled={loading}
-            onClick={address ? onNext : generateAddress}
+            onClick={onNext}
           >
             {loading ? (
               <Loader className="w-4 h-4 animate-spin" />
             ) : (
               <>
-                <span>
-                  {address
-                    ? t('depositModal.common.finish')
-                    : t('depositModal.step2.actions.generateAddressCta')}
-                </span>
+                <span>{t('depositModal.common.finish')}</span>
                 <ArrowRight className="w-3.5 h-3.5" />
               </>
             )}

--- a/src/components/MnemonicDisplay/index.tsx
+++ b/src/components/MnemonicDisplay/index.tsx
@@ -1,6 +1,6 @@
 import {
   Copy,
-  AlertCircle,
+  AlertTriangle,
   ArrowRight,
   ArrowLeft,
   SkipForward,
@@ -26,11 +26,7 @@ export const MnemonicDisplay = ({
   return (
     <div className="w-full space-y-5">
       {/* Warning Message */}
-      <Alert
-        icon={<AlertCircle className="w-5 h-5" />}
-        title="Important"
-        variant="warning"
-      >
+      <Alert icon={<AlertTriangle className="w-5 h-5" />} variant="warning">
         <p className="text-sm">
           Never share your recovery phrase with anyone. Store it securely
           offline. Anyone with access to this phrase can control your wallet.
@@ -94,7 +90,7 @@ export const MnemonicDisplay = ({
       {/* Skip Button */}
       {onSkip && (
         <Button
-          className="w-full text-content-secondary border-border-default/50 hover:bg-surface-overlay/50 hover:text-content-secondary hover:border-border-default"
+          className="w-full border-white/30 hover:border-white/50 bg-transparent hover:bg-white/5 text-white"
           icon={<SkipForward className="w-4 h-4" />}
           onClick={onSkip}
           size="md"

--- a/src/components/NotificationSystem/index.tsx
+++ b/src/components/NotificationSystem/index.tsx
@@ -5,6 +5,7 @@ import {
   X,
   Bell,
   Download,
+  MailOpen,
 } from 'lucide-react'
 import React, { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -247,11 +248,14 @@ const NotificationPanel: React.FC<{
             <Bell className="w-5 h-5 text-primary" />
             <h2 className="text-lg font-semibold text-white">Notifications</h2>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-5">
             <button
-              className="text-sm text-content-secondary hover:text-white"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border
+                         border-white/30 hover:border-white/50 bg-transparent hover:bg-surface-high/50
+                         text-white transition-colors"
               onClick={onClearAll}
             >
+              <MailOpen className="w-4 h-4" />
               Clear all
             </button>
             <button

--- a/src/components/PeerManagementModal/index.tsx
+++ b/src/components/PeerManagementModal/index.tsx
@@ -1,14 +1,10 @@
 import { Users, Plus, Loader, X, Link as LinkIcon, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { createPortal } from 'react-dom'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'react-toastify'
 
-import {
-  getModalPortalTarget,
-  getModalPositionClass,
-} from '../../helpers/modalPortal'
+import { Modal } from '../ui/Modal'
 import { nodeApi } from '../../slices/nodeApi/nodeApi.slice'
 
 interface PeerManagementModalProps {
@@ -63,56 +59,46 @@ export const PeerManagementModal = ({ onClose }: PeerManagementModalProps) => {
     }
   }
 
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      onClose()
-    }
-  }
-
-  const pos = getModalPositionClass()
-
-  return createPortal(
-    <div
-      className={`${pos} inset-0 bg-black/50 backdrop-blur-sm flex items-start justify-center z-50 pt-20`}
-      onMouseDown={handleBackdropClick}
-    >
-      <div className="bg-surface-base rounded-2xl border border-border-subtle p-6 max-w-2xl w-full m-4 max-h-[calc(100vh-120px)] overflow-y-auto">
-        <div className="flex justify-between items-center mb-6">
-          <div className="flex items-center gap-3">
-            <Users className="w-6 h-6 text-blue-500" />
-            <h2 className="text-2xl font-bold text-white">
-              {t('peerManagement.title')}
-            </h2>
-          </div>
-          <button
-            className="text-content-secondary hover:text-white transition-colors"
-            onClick={onClose}
-          >
-            <X className="w-5 h-5" />
-          </button>
+  return (
+    <Modal isOpen onClose={onClose} size="md">
+      <div className="flex items-center justify-between p-4 border-b border-divider/10">
+        <div className="flex items-center gap-3">
+          <Users className="w-5 h-5 text-primary" />
+          <h3 className="text-xl font-semibold text-white">
+            {t('peerManagement.title')}
+          </h3>
         </div>
+        <button
+          aria-label="Close modal"
+          className="p-2 rounded-full hover:bg-surface-overlay text-content-secondary hover:text-white transition-colors"
+          onClick={onClose}
+        >
+          <X size={20} />
+        </button>
+      </div>
 
+      <div className="p-6 space-y-6">
         {showConnectForm ? (
-          <form className="mb-6" onSubmit={handleSubmit(handleConnect)}>
+          <form onSubmit={handleSubmit(handleConnect)}>
             <div className="flex gap-3">
               <input
                 {...register('peerAddress')}
-                className="flex-1 bg-surface-overlay border border-border-default rounded-xl px-4 py-3 text-white
-                         placeholder-slate-500 focus:outline-none focus:border-blue-500"
+                className="flex-1 bg-surface-overlay border border-border-default rounded-lg px-4 py-2.5 text-sm text-white
+                         placeholder-content-tertiary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20"
                 placeholder={t('peerManagement.peerPlaceholder')}
                 type="text"
               />
               <button
                 className="px-4 py-2 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-lg
-                         font-medium transition-colors flex items-center gap-2"
+                         text-sm font-medium transition-colors flex items-center gap-2"
                 type="submit"
               >
                 <LinkIcon className="w-4 h-4" />
                 {t('peerManagement.connect')}
               </button>
               <button
-                className="px-4 py-2 bg-surface-overlay hover:bg-surface-high text-content-secondary
-                         rounded-lg font-medium transition-colors"
+                className="px-4 py-2 text-content-secondary hover:text-white hover:bg-surface-overlay/50
+                         rounded-lg text-sm font-medium transition-colors"
                 onClick={() => setShowConnectForm(false)}
                 type="button"
               >
@@ -122,25 +108,25 @@ export const PeerManagementModal = ({ onClose }: PeerManagementModalProps) => {
           </form>
         ) : (
           <button
-            className="w-full mb-6 px-4 py-3 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-lg
-                     font-medium transition-colors flex items-center justify-center gap-2"
+            className="w-full px-4 py-2.5 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-lg
+                     text-sm font-medium transition-colors flex items-center justify-center gap-2"
             onClick={() => setShowConnectForm(true)}
           >
-            <Plus className="w-5 h-5" />
+            <Plus className="w-4 h-4" />
             {t('peerManagement.connectToPeer')}
           </button>
         )}
 
         {isLoading ? (
           <div className="flex items-center justify-center py-8">
-            <Loader className="w-6 h-6 animate-spin text-blue-500" />
+            <Loader className="w-5 h-5 animate-spin text-primary" />
           </div>
         ) : peersData?.peers && peersData.peers.length > 0 ? (
           <div className="space-y-3">
             {peersData.peers.map((peer: any) => (
               <div
-                className="bg-surface-overlay/50 rounded-xl border border-border-default p-4
-                         flex items-center gap-3 justify-between group hover:border-red-500/20 hover:bg-red-500/5"
+                className="bg-surface-overlay/50 rounded-lg border border-border-default p-4
+                         flex items-center gap-3 justify-between group hover:border-red-500/20 hover:bg-red-500/5 transition-colors"
                 key={peer.pubkey}
               >
                 <div className="w-8 h-8 rounded-full bg-surface-high flex items-center justify-center flex-shrink-0 border border-border-default/60">
@@ -169,12 +155,11 @@ export const PeerManagementModal = ({ onClose }: PeerManagementModalProps) => {
             ))}
           </div>
         ) : (
-          <div className="text-center py-8 text-content-secondary">
+          <div className="text-center py-8 text-content-secondary text-sm">
             {t('peerManagement.noPeers')}
           </div>
         )}
       </div>
-    </div>,
-    getModalPortalTarget()
+    </Modal>
   )
 }

--- a/src/components/SkipMnemonicWarningModal/index.tsx
+++ b/src/components/SkipMnemonicWarningModal/index.tsx
@@ -21,9 +21,7 @@ export const SkipMnemonicWarningModal = ({
           <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-status-danger/10 border border-status-danger/20 shrink-0">
             <AlertTriangle className="w-5 h-5 text-status-danger" />
           </div>
-          <h2 className="text-xl font-bold text-white">
-            Skip Recovery Phrase?
-          </h2>
+          <h2 className="text-xl font-bold text-white">Skip Recovery Phrase</h2>
         </div>
 
         {/* Warning Content */}
@@ -48,20 +46,20 @@ export const SkipMnemonicWarningModal = ({
         {/* Action Buttons */}
         <div className="flex flex-col gap-2.5">
           <Button
-            className="w-full"
-            onClick={onCancel}
-            size="lg"
-            variant="primary"
-          >
-            Go Back and Save Recovery Phrase
-          </Button>
-          <Button
-            className="w-full border-status-danger/30 text-status-danger hover:bg-status-danger/10 hover:border-status-danger/50"
+            className="w-full bg-red-600/80 hover:bg-red-600 text-white border-transparent"
             onClick={onConfirm}
             size="lg"
             variant="outline"
           >
             Skip Anyway
+          </Button>
+          <Button
+            className="w-full border-white/30 hover:border-white/50 bg-transparent hover:bg-white/5 text-white"
+            onClick={onCancel}
+            size="lg"
+            variant="outline"
+          >
+            Save Recovery Phrase
           </Button>
         </div>
 

--- a/src/components/SupportModal/index.tsx
+++ b/src/components/SupportModal/index.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   AlertTriangle,
   CheckCircle,
+  ChevronDown,
   ChevronRight,
 } from 'lucide-react'
 import { useState } from 'react'
@@ -205,7 +206,7 @@ export const SupportModal = ({ isOpen, onClose }: SupportModalProps) => {
                   className="bg-surface-overlay/50 border border-divider/20 rounded-xl p-4 cursor-pointer hover:bg-surface-elevated/30 transition-colors duration-200 group"
                   onClick={() =>
                     openExternalLink(
-                      'https://github.com/kaleidoswap/desktop-app'
+                      'https://github.com/kaleidoswap/desktop-app/issues'
                     )
                   }
                 >
@@ -252,10 +253,10 @@ export const SupportModal = ({ isOpen, onClose }: SupportModalProps) => {
           {activeSection === 'troubleshoot' && (
             <div className="space-y-5">
               <button
-                className="flex items-center gap-2 text-primary hover:underline mb-4"
+                className="px-3 py-2 text-content-secondary hover:text-white transition-colors flex items-center gap-1.5 hover:bg-surface-overlay/50 rounded-lg text-sm mb-4"
                 onClick={goBack}
               >
-                <ChevronRight className="w-4 h-4 rotate-180" />
+                <ChevronRight className="w-3.5 h-3.5 rotate-180" />
                 <span>{t('supportModal.backToSupport')}</span>
               </button>
 
@@ -284,20 +285,21 @@ export const SupportModal = ({ isOpen, onClose }: SupportModalProps) => {
                           </p>
                         </div>
                       </div>
-                      <button className="p-1 text-content-secondary hover:text-white transition-colors">
-                        {expandedIssue === index ? (
+                      {expandedIssue === index ? (
+                        <button className="p-1 text-content-secondary hover:text-white transition-colors">
                           <X className="w-5 h-5" />
-                        ) : (
-                          <span className="text-primary">
-                            {t('supportModal.viewSolutions')}
-                          </span>
-                        )}
-                      </button>
+                        </button>
+                      ) : (
+                        <button className="px-3 py-2 text-content-secondary hover:text-white transition-colors flex items-center gap-1.5 hover:bg-surface-overlay/50 rounded-lg text-sm">
+                          <span>{t('supportModal.viewSolutions')}</span>
+                          <ChevronDown className="w-3.5 h-3.5" />
+                        </button>
+                      )}
                     </div>
 
                     {expandedIssue === index && (
                       <div className="px-5 pb-5 pt-2 border-t border-divider/20 bg-surface-base/30">
-                        <h4 className="text-sm font-semibold text-primary mb-3">
+                        <h4 className="text-sm font-semibold text-white mb-3">
                           {t('supportModal.solutions')}
                         </h4>
                         <ul className="space-y-2">

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -1261,7 +1261,7 @@ const NodeSelectionModalContent: React.FC<NodeSelectionModalContentProps> = ({
       {loadingState && (
         <div className="bg-primary/10 border border-primary/30 rounded-lg p-4 mb-4">
           <div className="flex items-center gap-3">
-            <AlertTriangle className="w-5 h-5 text-primary shrink-0" />
+            <Loader2 className="w-5 h-5 text-primary shrink-0 animate-spin" />
             <p className="text-primary font-medium">{loadingState.message}</p>
           </div>
         </div>

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -1051,7 +1051,7 @@ const CopyField = ({ label, value }: { label: string; value: string }) => {
       <label className="text-xs font-medium text-content-secondary uppercase tracking-wider">
         {label}
       </label>
-      <div className="mt-1.5 flex items-center gap-2 px-3 py-2 rounded-lg border border-border-default/50 bg-surface-overlay/30 group">
+      <div className="mt-1.5 flex items-center gap-2 px-3 py-2 rounded-lg border border-border-default/50 bg-surface-base group">
         <span className="flex-1 text-sm text-white break-all font-mono">
           {value}
         </span>
@@ -1089,7 +1089,7 @@ const AccordionSection = ({
         border rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary/20
         ${
           isOpen
-            ? 'border-primary bg-surface-elevated/60 shadow-[0_0_10px_rgba(21,233,154,0.15)] rounded-b-none'
+            ? 'border-border-default/50 bg-surface-overlay/50 rounded-b-none'
             : 'border-border-default/50 bg-surface-overlay/30 hover:bg-surface-overlay/50 hover:border-border-default/70'
         }`}
       onClick={onToggle}
@@ -1101,7 +1101,7 @@ const AccordionSection = ({
       />
     </button>
     {isOpen && (
-      <div className="p-4 border border-t-0 border-primary/50 rounded-b-lg bg-surface-elevated/60 space-y-3">
+      <div className="p-4 border border-t-0 border-border-default/50 rounded-b-lg bg-surface-overlay/30 space-y-3">
         {children}
       </div>
     )}

--- a/src/components/UTXOManagementModal/index.tsx
+++ b/src/components/UTXOManagementModal/index.tsx
@@ -1,17 +1,26 @@
-import { Plus, Loader, Zap, Wallet, Paintbrush } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
-import { createPortal } from 'react-dom'
-import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
-
-import { CREATEUTXOS_PATH } from '../../app/router/paths'
 import {
-  getModalPortalTarget,
-  getModalPositionClass,
-} from '../../helpers/modalPortal'
+  Plus,
+  Loader,
+  Zap,
+  Wallet,
+  Paintbrush,
+  ArrowLeft,
+  Info,
+  Database,
+  Clock,
+  Rocket,
+  Settings,
+  X,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'react-toastify'
+
 import { formatBitcoinAmount } from '../../helpers/number'
 import { nodeApi } from '../../slices/nodeApi/nodeApi.slice'
 import { getAssignmentAmount } from '../../utils/rgbUtils'
+import { Modal } from '../ui/Modal'
 
 interface UTXOManagementModalProps {
   onClose: () => void
@@ -27,12 +36,20 @@ interface UTXOSummary {
   normalCount: number
 }
 
+interface CreateFormFields {
+  num: number
+  size: number
+  fee_rate: string
+}
+
 export const UTXOManagementModal = ({
   onClose,
   bitcoinUnit,
 }: UTXOManagementModalProps) => {
-  const navigate = useNavigate()
   const { t } = useTranslation()
+  const [step, setStep] = useState<'list' | 'create'>('list')
+
+  // ── List step state ──────────────────────────────────────────────────────
   const [listUnspents, { data: unspentsData, isLoading }] =
     nodeApi.useLazyListUnspentsQuery()
 
@@ -58,11 +75,6 @@ export const UTXOManagementModal = ({
         },
       }
     }
-
-    // Separate UTXOs into:
-    // 1. Colorable (can be used for RGB assets but not yet allocated)
-    // 2. Colored (already have RGB allocations)
-    // 3. Normal (can't be used for RGB assets)
 
     const colored = unspentsData.unspents.filter(
       (u: any) =>
@@ -107,36 +119,22 @@ export const UTXOManagementModal = ({
     'all' | 'colorable' | 'colored' | 'normal'
   >('all')
 
-  const handleCreateUTXOs = () => {
-    onClose()
-    navigate(CREATEUTXOS_PATH)
-  }
-
   const getUtxoStatusLabel = (unspent: any) => {
-    if (!unspent.utxo?.colorable) {
-      return t('utxoManagement.status.normal')
-    }
-    if (unspent.rgb_allocations && unspent.rgb_allocations.length > 0) {
+    if (!unspent.utxo?.colorable) return t('utxoManagement.status.normal')
+    if (unspent.rgb_allocations && unspent.rgb_allocations.length > 0)
       return t('utxoManagement.status.colored')
-    }
     return t('utxoManagement.status.colorable')
   }
 
   const getUtxoStatusStyle = (unspent: any) => {
-    if (!unspent.utxo?.colorable) {
-      return 'bg-blue-500/20 text-blue-400'
-    }
-    if (unspent.rgb_allocations && unspent.rgb_allocations.length > 0) {
+    if (!unspent.utxo?.colorable) return 'bg-blue-500/20 text-blue-400'
+    if (unspent.rgb_allocations && unspent.rgb_allocations.length > 0)
       return 'bg-purple-500/20 text-purple-400'
-    }
     return 'bg-green-500/20 text-green-400'
   }
 
-  const UTXOCard = ({ unspent }: { unspent: any; index: number }) => (
-    <div
-      className="bg-surface-overlay/50 rounded-xl border border-border-default p-4"
-      key={unspent.utxo.outpoint}
-    >
+  const UTXOCard = ({ unspent }: { unspent: any }) => (
+    <div className="bg-surface-overlay/50 rounded-lg border border-border-default p-4">
       <div className="flex justify-between items-start mb-2">
         <div className="text-sm font-medium text-content-secondary">
           {unspent.utxo?.outpoint?.split(':')[0]}
@@ -172,12 +170,6 @@ export const UTXOManagementModal = ({
       )}
     </div>
   )
-
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      onClose()
-    }
-  }
 
   const summaryCards = [
     {
@@ -215,166 +207,421 @@ export const UTXOManagementModal = ({
     },
   ]
 
-  const pos = getModalPositionClass()
+  // ── Create step state ────────────────────────────────────────────────────
+  const [feeEstimations, setFeeEstimations] = useState({
+    fast: 3,
+    normal: 2,
+    slow: 1,
+  })
+  const [customFee, setCustomFee] = useState(1.0)
+  const [isCreating, setIsCreating] = useState(false)
 
-  return createPortal(
-    <div
-      className={`${pos} inset-0 bg-black/50 backdrop-blur-sm flex items-start justify-center z-50 pt-20`}
-      onMouseDown={handleBackdropClick}
-    >
-      <div className="bg-surface-base rounded-2xl border border-border-subtle p-6 max-w-4xl w-full m-4 max-h-[calc(100vh-120px)] overflow-y-auto">
-        <div className="flex justify-between items-center mb-6">
-          <h2 className="text-2xl font-bold text-white">
-            {t('utxoManagement.title')}
-          </h2>
-          <button
-            className="text-content-secondary hover:text-white transition-colors"
-            onClick={onClose}
-          >
-            ✕
-          </button>
+  const { handleSubmit, register, watch, setValue } = useForm<CreateFormFields>(
+    {
+      defaultValues: { fee_rate: 'normal', num: 4, size: 32500 },
+    }
+  )
+
+  const feeRateOptions = [
+    {
+      icon: <Clock className="w-4 h-4" />,
+      label: t('withdrawModal.form.fees.options.slow'),
+      rate: feeEstimations.slow,
+      value: 'slow',
+    },
+    {
+      icon: <Zap className="w-4 h-4" />,
+      label: t('withdrawModal.form.fees.options.normal'),
+      rate: feeEstimations.normal,
+      value: 'normal',
+    },
+    {
+      icon: <Rocket className="w-4 h-4" />,
+      label: t('withdrawModal.form.fees.options.fast'),
+      rate: feeEstimations.fast,
+      value: 'fast',
+    },
+    {
+      icon: <Settings className="w-4 h-4" />,
+      label: t('withdrawModal.form.fees.options.custom'),
+      rate: customFee,
+      value: 'custom',
+    },
+  ]
+
+  const num = watch('num')
+  const size = watch('size')
+  const feeRate = watch('fee_rate')
+
+  const [btcBalance, btcBalanceResponse] =
+    nodeApi.endpoints.btcBalance.useLazyQuery()
+  const [createutxos] = nodeApi.useCreateUtxosMutation()
+  const [estimateFee] = nodeApi.useLazyEstimateFeeQuery()
+
+  const refreshBalance = useCallback(() => {
+    btcBalance()
+  }, [btcBalance])
+
+  useEffect(() => {
+    if (step !== 'create') return
+    const fetchFees = async () => {
+      try {
+        const [slowFee, normalFee, fastFee] = await Promise.all([
+          estimateFee({ blocks: 6 }).unwrap(),
+          estimateFee({ blocks: 3 }).unwrap(),
+          estimateFee({ blocks: 1 }).unwrap(),
+        ])
+        setFeeEstimations({
+          fast: Math.round(fastFee.fee_rate ?? 3),
+          normal: Math.round(normalFee.fee_rate ?? 2),
+          slow: Math.round(slowFee.fee_rate ?? 1),
+        })
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    fetchFees()
+    refreshBalance()
+    const intervalId = setInterval(refreshBalance, 15_000)
+    return () => clearInterval(intervalId)
+  }, [step, estimateFee, refreshBalance])
+
+  const onSubmitCreate = (data: CreateFormFields) => {
+    setIsCreating(true)
+    createutxos({
+      fee_rate: Math.round(
+        data.fee_rate === 'slow'
+          ? feeEstimations.slow
+          : data.fee_rate === 'normal'
+            ? feeEstimations.normal
+            : data.fee_rate === 'fast'
+              ? feeEstimations.fast
+              : customFee
+      ),
+      num: data.num,
+      size: data.size,
+      up_to: false,
+    }).then((res: any) => {
+      setIsCreating(false)
+      if (res.error) {
+        toast.error(res.error.data.error)
+      } else {
+        toast.success(t('createUtxos.toastSuccess'))
+        listUnspents()
+        setStep('list')
+      }
+    })
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────────
+  return (
+    <Modal isOpen onClose={onClose} size="lg">
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b border-divider/10">
+        <div className="flex items-center gap-3">
+          {step === 'create' ? (
+            <Paintbrush className="w-5 h-5 text-purple-400" />
+          ) : (
+            <Database className="w-5 h-5 text-primary" />
+          )}
+          <h3 className="text-xl font-semibold text-white">
+            {step === 'list'
+              ? t('utxoManagement.title')
+              : t('createUtxos.title')}
+          </h3>
         </div>
-
-        {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-          {summaryCards.map((card) => (
-            <div
-              className="bg-surface-overlay/50 rounded-xl border border-border-default p-4 flex flex-col"
-              key={card.key}
-            >
-              <div className="flex items-center gap-2 mb-2">
-                {card.icon}
-                <h3 className="text-lg font-medium text-white">{card.title}</h3>
-              </div>
-              <div className="flex flex-col gap-1.5 flex-1">
-                {card.bullets.map((bullet) => (
-                  <div
-                    className="flex items-center gap-2 text-sm text-content-secondary"
-                    key={bullet}
-                  >
-                    <div className={`w-2 h-2 rounded-full ${card.dotClass}`} />
-                    <span>{bullet}</span>
-                  </div>
-                ))}
-              </div>
-              <div className="mt-4 pt-3 border-t border-border-default/50">
-                <div className="text-2xl font-bold text-white">
-                  {formatBitcoinAmount(card.total, bitcoinUnit)} {bitcoinUnit}
-                </div>
-                <div className="text-sm text-content-secondary mt-0.5">
-                  {t('utxoManagement.summary.countLabel', {
-                    count: card.count,
-                  })}
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-
         <button
-          className="w-full mb-6 px-4 py-3 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-lg 
-                   font-medium transition-colors flex items-center justify-center gap-2"
-          onClick={handleCreateUTXOs}
+          aria-label="Close modal"
+          className="p-2 rounded-full hover:bg-surface-overlay text-content-secondary hover:text-white transition-colors"
+          onClick={onClose}
         >
-          <Plus className="w-5 h-5" />
-          {t('utxoManagement.actions.create')}
+          <X size={20} />
         </button>
-
-        {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <Loader className="w-6 h-6 animate-spin text-blue-500" />
-          </div>
-        ) : unspentsData?.unspents && unspentsData.unspents.length > 0 ? (
-          <div>
-            {/* Filter chips */}
-            <div className="flex items-center gap-2 mb-4 flex-wrap">
-              {(
-                [
-                  {
-                    count:
-                      colorableUtxos.length +
-                      coloredUtxos.length +
-                      normalUtxos.length,
-                    icon: null,
-                    key: 'all',
-                    label: t('utxoManagement.filter.all'),
-                  },
-                  {
-                    count: colorableUtxos.length,
-                    icon: <Zap className="w-3.5 h-3.5" />,
-                    key: 'colorable',
-                    label: t('utxoManagement.sections.colorable'),
-                  },
-                  {
-                    count: coloredUtxos.length,
-                    icon: <Paintbrush className="w-3.5 h-3.5" />,
-                    key: 'colored',
-                    label: t('utxoManagement.sections.colored'),
-                  },
-                  {
-                    count: normalUtxos.length,
-                    icon: <Wallet className="w-3.5 h-3.5" />,
-                    key: 'normal',
-                    label: t('utxoManagement.sections.normal'),
-                  },
-                ] as const
-              ).map(({ key, label, count, icon }) => (
-                <button
-                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 border
-                    ${
-                      activeFilter === key
-                        ? 'bg-white/15 border-white/30 text-white'
-                        : 'bg-white/5 border-white/10 text-content-tertiary hover:border-white/20 hover:text-content-secondary'
-                    }`}
-                  key={key}
-                  onClick={() => setActiveFilter(key)}
-                >
-                  {icon}
-                  {label}
-                  <span
-                    className={`text-xs px-1.5 py-0.5 rounded-full ${activeFilter === key ? 'bg-white/20' : 'bg-white/10'}`}
-                  >
-                    {count}
-                  </span>
-                </button>
-              ))}
-            </div>
-
-            {/* Filtered UTXO list */}
-            <div className="space-y-3">
-              {(activeFilter === 'all' || activeFilter === 'colorable') &&
-                colorableUtxos.map((unspent: any, index: number) => (
-                  <UTXOCard
-                    index={index}
-                    key={unspent.utxo?.outpoint || index}
-                    unspent={unspent}
-                  />
-                ))}
-              {(activeFilter === 'all' || activeFilter === 'colored') &&
-                coloredUtxos.map((unspent: any, index: number) => (
-                  <UTXOCard
-                    index={index}
-                    key={unspent.utxo?.outpoint || index}
-                    unspent={unspent}
-                  />
-                ))}
-              {(activeFilter === 'all' || activeFilter === 'normal') &&
-                normalUtxos.map((unspent: any, index: number) => (
-                  <UTXOCard
-                    index={index}
-                    key={unspent.utxo?.outpoint || index}
-                    unspent={unspent}
-                  />
-                ))}
-            </div>
-          </div>
-        ) : (
-          <div className="text-center py-8 text-content-secondary">
-            {t('utxoManagement.empty')}
-          </div>
-        )}
       </div>
-    </div>,
-    getModalPortalTarget()
+
+      {/* Body */}
+      {step === 'list' ? (
+        <div className="p-6 space-y-6">
+          {/* Summary Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {summaryCards.map((card) => (
+              <div
+                className="bg-surface-overlay/50 rounded-lg border border-border-default p-4 flex flex-col"
+                key={card.key}
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  {card.icon}
+                  <h3 className="text-base font-medium text-white">
+                    {card.title}
+                  </h3>
+                </div>
+                <div className="flex flex-col gap-1.5 flex-1">
+                  {card.bullets.map((bullet) => (
+                    <div
+                      className="flex items-center gap-2 text-sm text-content-secondary"
+                      key={bullet}
+                    >
+                      <div
+                        className={`w-2 h-2 rounded-full ${card.dotClass}`}
+                      />
+                      <span>{bullet}</span>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-4 pt-3 border-t border-border-default/50">
+                  <div className="text-xl font-bold text-white">
+                    {formatBitcoinAmount(card.total, bitcoinUnit)} {bitcoinUnit}
+                  </div>
+                  <div className="text-sm text-content-secondary mt-0.5">
+                    {t('utxoManagement.summary.countLabel', {
+                      count: card.count,
+                    })}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <button
+            className="w-full px-4 py-2.5 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-lg
+                     text-sm font-medium transition-colors flex items-center justify-center gap-2"
+            onClick={() => setStep('create')}
+          >
+            <Plus className="w-4 h-4" />
+            {t('utxoManagement.actions.create')}
+          </button>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader className="w-5 h-5 animate-spin text-primary" />
+            </div>
+          ) : unspentsData?.unspents && unspentsData.unspents.length > 0 ? (
+            <div>
+              {/* Filter tabs */}
+              <div className="flex gap-1 rounded-xl bg-surface-overlay/40 p-1 mb-4 w-fit">
+                {(
+                  [
+                    {
+                      count:
+                        colorableUtxos.length +
+                        coloredUtxos.length +
+                        normalUtxos.length,
+                      icon: null,
+                      key: 'all',
+                      label: t('utxoManagement.filter.all'),
+                    },
+                    {
+                      count: colorableUtxos.length,
+                      icon: <Zap className="h-3.5 w-3.5" />,
+                      key: 'colorable',
+                      label: t('utxoManagement.sections.colorable'),
+                    },
+                    {
+                      count: coloredUtxos.length,
+                      icon: <Paintbrush className="h-3.5 w-3.5" />,
+                      key: 'colored',
+                      label: t('utxoManagement.sections.colored'),
+                    },
+                    {
+                      count: normalUtxos.length,
+                      icon: <Wallet className="h-3.5 w-3.5" />,
+                      key: 'normal',
+                      label: t('utxoManagement.sections.normal'),
+                    },
+                  ] as const
+                ).map(({ key, label, count, icon }) => (
+                  <button
+                    className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:outline-none ${
+                      activeFilter === key
+                        ? 'bg-primary/15 text-primary border border-primary/30'
+                        : 'text-content-secondary hover:text-white border border-transparent'
+                    }`}
+                    key={key}
+                    onClick={() => setActiveFilter(key)}
+                  >
+                    {icon}
+                    {label}
+                    <span
+                      className={`text-xs ${activeFilter === key ? 'text-primary' : 'text-white/60'}`}
+                    >
+                      ({count})
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              {/* UTXO list */}
+              <div className="space-y-3">
+                {(activeFilter === 'all' || activeFilter === 'colorable') &&
+                  colorableUtxos.map((u: any) => (
+                    <UTXOCard key={u.utxo?.outpoint} unspent={u} />
+                  ))}
+                {(activeFilter === 'all' || activeFilter === 'colored') &&
+                  coloredUtxos.map((u: any) => (
+                    <UTXOCard key={u.utxo?.outpoint} unspent={u} />
+                  ))}
+                {(activeFilter === 'all' || activeFilter === 'normal') &&
+                  normalUtxos.map((u: any) => (
+                    <UTXOCard key={u.utxo?.outpoint} unspent={u} />
+                  ))}
+              </div>
+            </div>
+          ) : (
+            <div className="text-center py-8 text-content-secondary text-sm">
+              {t('utxoManagement.empty')}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="p-6 space-y-6">
+          {/* Description */}
+          <div className="flex items-start gap-3 rounded-lg bg-blue-500/10 border border-blue-500/20 p-4">
+            <Info className="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-blue-300">
+              {t('createUtxos.description')}
+            </p>
+          </div>
+
+          <form className="space-y-6" onSubmit={handleSubmit(onSubmitCreate)}>
+            {/* Number of UTXOs */}
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-content-secondary">
+                {t('createUtxos.fields.numberOfUtxos')}
+              </label>
+              <input
+                {...register('num', { valueAsNumber: true })}
+                className="w-full bg-surface-overlay/50 text-white px-4 py-2.5 rounded-lg border border-border-default
+                         focus:border-primary/50 focus:ring-1 focus:ring-primary/20 focus:outline-none text-sm"
+                max={10}
+                min={1}
+                placeholder={t('createUtxos.fields.numberPlaceholder')}
+                type="number"
+              />
+            </div>
+
+            {/* UTXO Size */}
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-content-secondary">
+                {t('createUtxos.fields.sizeLabel')}
+              </label>
+              <div className="flex items-center gap-4">
+                <input
+                  {...register('size', { valueAsNumber: true })}
+                  className="flex-1 bg-surface-overlay/50 text-white px-4 py-2.5 rounded-lg border border-border-default
+                           focus:border-primary/50 focus:ring-1 focus:ring-primary/20 focus:outline-none text-sm"
+                  max={
+                    btcBalanceResponse.data
+                      ? Math.floor(
+                          (btcBalanceResponse.data?.vanilla?.spendable ?? 0) /
+                            num
+                        )
+                      : 0
+                  }
+                  min={0}
+                  placeholder={t('createUtxos.fields.sizePlaceholder')}
+                  type="number"
+                />
+                <span className="text-base font-semibold text-white min-w-[100px] text-right">
+                  {size.toLocaleString()}
+                </span>
+              </div>
+              <input
+                className="w-full h-2 bg-surface-high rounded-lg appearance-none cursor-pointer mt-2"
+                max={
+                  btcBalanceResponse.data
+                    ? Math.floor(
+                        (btcBalanceResponse.data?.vanilla?.spendable ?? 0) / num
+                      )
+                    : 0
+                }
+                min={0}
+                onChange={(e) => setValue('size', Number(e.target.value))}
+                step="1000"
+                type="range"
+                value={size}
+              />
+            </div>
+
+            {/* Available balance */}
+            <p className="text-sm text-content-secondary">
+              {t('createUtxos.fields.availableBalance', {
+                defaultValue: 'Available Balance',
+              })}
+              :{' '}
+              <span className="text-white font-semibold">
+                {btcBalanceResponse.data
+                  ? (
+                      btcBalanceResponse.data?.vanilla?.spendable ?? 0
+                    ).toLocaleString()
+                  : '0'}{' '}
+                sats
+              </span>
+            </p>
+
+            {/* Fee Rate */}
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-content-secondary">
+                {t('createUtxos.fields.feeRate')}
+              </label>
+              <div className="grid grid-cols-4 gap-2">
+                {feeRateOptions.map((fee) => (
+                  <button
+                    className={`py-1.5 px-2 flex flex-col items-center justify-center gap-0.5
+                            rounded-lg transition-colors duration-200 border text-xs
+                            ${
+                              feeRate === fee.value
+                                ? 'bg-primary/10 border-primary text-primary'
+                                : 'border-border-default hover:border-primary/50 text-content-secondary'
+                            }`}
+                    key={fee.value}
+                    onClick={() => setValue('fee_rate', fee.value)}
+                    type="button"
+                  >
+                    {fee.icon}
+                    <span className="text-[10px]">{fee.label}</span>
+                    <span className="text-[9px]">{fee.rate} sat/vB</span>
+                  </button>
+                ))}
+              </div>
+              {feeRate === 'custom' && (
+                <input
+                  className="w-full bg-surface-overlay/50 text-white px-4 py-2.5 mt-2 rounded-lg border border-border-default
+                           focus:border-primary/50 focus:ring-1 focus:ring-primary/20 focus:outline-none text-sm"
+                  defaultValue={customFee}
+                  onChange={(e) => setCustomFee(parseFloat(e.target.value))}
+                  step={0.1}
+                  type="number"
+                />
+              )}
+            </div>
+
+            {/* Footer actions */}
+            <div className="flex justify-between items-center pt-2">
+              <button
+                className="px-3 py-2 text-content-secondary hover:text-white transition-colors flex items-center gap-1.5 hover:bg-surface-overlay/50 rounded-lg text-sm"
+                onClick={() => setStep('list')}
+                type="button"
+              >
+                <ArrowLeft className="w-3.5 h-3.5" />
+                <span>{t('common.back')}</span>
+              </button>
+              <button
+                className="px-4 py-2 bg-primary hover:bg-primary-emphasis disabled:opacity-50 disabled:cursor-not-allowed
+                         text-primary-foreground rounded-lg transition-colors flex items-center gap-1.5 text-sm font-semibold"
+                disabled={isCreating}
+                type="submit"
+              >
+                {isCreating ? (
+                  <Loader className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Plus className="w-4 h-4" />
+                )}
+                {t('createUtxos.actions.create')}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </Modal>
   )
 }

--- a/src/routes/channels/index.tsx
+++ b/src/routes/channels/index.tsx
@@ -393,7 +393,7 @@ export const Component: React.FC = () => {
                   }`}
                   onClick={() => setActiveTab('bitcoin')}
                 >
-                  <Bitcoin className="h-3.5 w-3.5 text-primary" />
+                  <Bitcoin className="h-3.5 w-3.5" />
                   {t('channels.bitcoin')}
                   <span
                     className={`text-xs ${activeTab === 'bitcoin' ? 'text-primary' : 'text-white/60'}`}

--- a/src/routes/kaleido-mind/brain-launcher.tsx
+++ b/src/routes/kaleido-mind/brain-launcher.tsx
@@ -20,6 +20,7 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { KALEIDO_MIND_MODELS_PATH } from '../../app/router/paths'
+import { Select } from '../../components/ui/Select'
 import type { UseMindResult } from '../../hooks/useMind'
 
 import { gb, labelForPhase } from './shared'
@@ -245,39 +246,15 @@ const StartBrain: React.FC<{ mind: UseMindResult }> = ({ mind }) => {
 
       <div className="mt-5 space-y-3">
         {installed.length > 1 && (
-          <div className="relative">
-            <select
-              className="appearance-none w-full pl-9 pr-8 py-2 border border-border-default rounded-lg bg-surface-overlay text-sm text-content-primary focus:outline-none focus:ring-2 focus:ring-primary"
-              onChange={(e) => setSelected(e.target.value)}
-              value={modelId}
-            >
-              {installed.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.displayName || m.id}
-                  {m.id === lastId ? ' · last used' : ''}
-                </option>
-              ))}
-            </select>
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <Cpu className="h-4 w-4 text-content-tertiary" />
-            </div>
-            <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-              <svg
-                className="h-4 w-4 text-content-tertiary"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9l-7 7-7-7"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                />
-              </svg>
-            </div>
-          </div>
+          <Select
+            icon={<Cpu className="h-4 w-4" />}
+            onChange={(val) => setSelected(val)}
+            options={installed.map((m) => ({
+              label: `${m.displayName || m.id}${m.id === lastId ? ' · last used' : ''}`,
+              value: m.id,
+            }))}
+            value={modelId}
+          />
         )}
         <button
           className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-primary px-3.5 py-2.5 text-sm font-semibold text-surface-base transition-all hover:bg-primary-emphasis active:scale-95 disabled:opacity-50"

--- a/src/routes/kaleido-mind/start-brain-modal.tsx
+++ b/src/routes/kaleido-mind/start-brain-modal.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { KALEIDO_MIND_BRAIN_PATH } from '../../app/router/paths'
 import { Modal } from '../../components/ui/Modal'
+import { Select } from '../../components/ui/Select'
 import type { UseMindResult } from '../../hooks/useMind'
 
 /** Remembers the last model you started, so "the latest" is the one you used. */
@@ -84,44 +85,20 @@ export const StartBrainModal: React.FC<{
         {installed.length > 0 ? (
           <>
             {installed.length > 1 && (
-              <label className="block">
+              <div className="block">
                 <span className="mb-1 block text-xs text-content-tertiary">
                   Model
                 </span>
-                <div className="relative">
-                  <select
-                    className="appearance-none w-full pl-9 pr-8 py-2 border border-border-default rounded-lg bg-surface-overlay text-sm text-content-primary focus:outline-none focus:ring-2 focus:ring-primary"
-                    onChange={(e) => setSelected(e.target.value)}
-                    value={modelId}
-                  >
-                    {installed.map((m) => (
-                      <option key={m.id} value={m.id}>
-                        {m.displayName || m.id}
-                        {m.id === lastId ? ' · last used' : ''}
-                      </option>
-                    ))}
-                  </select>
-                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                    <Cpu className="h-4 w-4 text-content-tertiary" />
-                  </div>
-                  <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                    <svg
-                      className="h-4 w-4 text-content-tertiary"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M19 9l-7 7-7-7"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </label>
+                <Select
+                  icon={<Cpu className="h-4 w-4" />}
+                  onChange={(val) => setSelected(val)}
+                  options={installed.map((m) => ({
+                    label: `${m.displayName || m.id}${m.id === lastId ? ' · last used' : ''}`,
+                    value: m.id,
+                  }))}
+                  value={modelId}
+                />
+              </div>
             )}
             <div className="flex gap-2">
               <button

--- a/src/routes/wallet-dashboard/index.tsx
+++ b/src/routes/wallet-dashboard/index.tsx
@@ -70,8 +70,16 @@ const BtcIcon: React.FC<{ className?: string }> = ({
 
 const ChannelAssetBadge: React.FC<{ ticker: string }> = ({ ticker }) => {
   const [imgSrc, setImgSrc] = useAssetIcon(ticker, defaultRgbIcon)
+  const isUsdt = ticker === 'USDT'
   return (
-    <span className="flex items-center gap-1 text-[10px] font-bold text-secondary bg-secondary/10 border border-secondary/20 px-1.5 py-0.5 rounded flex-shrink-0">
+    <span
+      className={`flex items-center gap-1 text-[10px] font-bold px-1.5 py-0.5 rounded flex-shrink-0 ${
+        isUsdt
+          ? 'bg-[#26A17B]/10 border border-[#26A17B]/20'
+          : 'text-secondary bg-secondary/10 border border-secondary/20'
+      }`}
+      style={isUsdt ? { color: '#26A17B' } : {}}
+    >
       <img
         alt={ticker}
         className="w-3 h-3 rounded-full object-contain"
@@ -79,6 +87,25 @@ const ChannelAssetBadge: React.FC<{ ticker: string }> = ({ ticker }) => {
         src={imgSrc}
       />
       {ticker}
+    </span>
+  )
+}
+
+const BarAssetLabel: React.FC<{ ticker: string }> = ({ ticker }) => {
+  const [imgSrc, setImgSrc] = useAssetIcon(ticker, defaultRgbIcon)
+  const isUsdt = ticker === 'USDT'
+  return (
+    <span
+      className="flex items-center justify-center gap-1 font-medium"
+      style={isUsdt ? { color: '#26A17B' } : {}}
+    >
+      <img
+        alt={ticker}
+        className="w-3 h-3 rounded-full object-contain"
+        onError={() => setImgSrc(defaultRgbIcon)}
+        src={imgSrc}
+      />
+      <span className={isUsdt ? '' : 'text-content-secondary'}>{ticker}</span>
     </span>
   )
 }
@@ -739,7 +766,7 @@ export const Component = () => {
 
                         {/* BTC liquidity bar */}
                         <div className="mb-1.5">
-                          <div className="grid grid-cols-3 items-center text-[10px] mb-0.5 max-h-0 overflow-hidden group-hover/ch:max-h-4 transition-all duration-200">
+                          <div className="grid grid-cols-3 items-center text-[10px] mb-0.5">
                             <span className="flex items-center gap-0.5 text-purple-400">
                               <ArrowUpRight className="w-2.5 h-2.5" />
                               {formatBitcoinAmount(
@@ -747,7 +774,8 @@ export const Component = () => {
                                 bitcoinUnit
                               )}
                             </span>
-                            <span className="text-center text-content-secondary font-medium">
+                            <span className="flex items-center justify-center gap-1 text-content-secondary font-medium">
+                              <BtcIcon className="w-3 h-3" />
                               BTC
                             </span>
                             <span className="flex items-center gap-0.5 text-emerald-400 justify-end">
@@ -769,7 +797,7 @@ export const Component = () => {
                             />
                             <div className="absolute top-0 bottom-0 left-1/2 -translate-x-1/2 w-px bg-surface-high/80" />
                           </div>
-                          <div className="grid grid-cols-3 text-[8px] font-semibold uppercase tracking-wider mt-0.5 max-h-0 overflow-hidden group-hover/ch:max-h-4 transition-all duration-200">
+                          <div className="grid grid-cols-3 text-[8px] font-semibold uppercase tracking-wider mt-0.5">
                             <span className="text-[#9365FF]/70">Outbound</span>
                             <span />
                             <span className="text-right text-emerald-400/70">
@@ -781,14 +809,12 @@ export const Component = () => {
                         {/* Asset liquidity bar (if RGB channel) */}
                         {asset && (
                           <div>
-                            <div className="grid grid-cols-3 items-center text-[10px] mb-0.5 max-h-0 overflow-hidden group-hover/ch:max-h-4 transition-all duration-200">
+                            <div className="grid grid-cols-3 items-center text-[10px] mb-0.5">
                               <span className="flex items-center gap-0.5 text-purple-400">
                                 <ArrowUpRight className="w-2.5 h-2.5" />
                                 {ch.asset_local_amount || 0}
                               </span>
-                              <span className="text-center text-lime-300/60 font-medium">
-                                {asset.ticker}
-                              </span>
+                              <BarAssetLabel ticker={asset.ticker} />
                               <span className="flex items-center gap-0.5 text-emerald-400 justify-end">
                                 {ch.asset_remote_amount || 0}
                                 <ArrowDownRight className="w-2.5 h-2.5" />
@@ -805,7 +831,7 @@ export const Component = () => {
                               />
                               <div className="absolute top-0 bottom-0 left-1/2 -translate-x-1/2 w-px bg-surface-high/80" />
                             </div>
-                            <div className="grid grid-cols-3 text-[8px] font-semibold uppercase tracking-wider mt-0.5 max-h-0 overflow-hidden group-hover/ch:max-h-4 transition-all duration-200">
+                            <div className="grid grid-cols-3 text-[8px] font-semibold uppercase tracking-wider mt-0.5">
                               <span className="text-[#9365FF]/70">
                                 Outbound
                               </span>

--- a/src/routes/wallet-remote/index.tsx
+++ b/src/routes/wallet-remote/index.tsx
@@ -997,7 +997,7 @@ export const Component = () => {
                       <div className="pt-3 space-y-3">
                         {/* Test Connection Button */}
                         <Button
-                          className="w-full"
+                          className="w-full border-white/30 hover:border-white/50 bg-transparent hover:bg-white/5 text-white"
                           disabled={isTestingConnection || isConnecting}
                           icon={
                             isTestingConnection ? (


### PR DESCRIPTION
## Summary

- **Channels**: Bitcoin icon inherits tab color (gray when unselected)
- **Deposit modal**: auto-generate address on mount for non-BTC flows; always show Finish CTA
- **KaleidoMind start modal**: replace native `<select>` with shared `Select` component
- **SupportModal**: standardize Back / View Solutions button styles; fix GitHub Issues URL; Solutions label white
- **PeerManagementModal**: refactor to shared `Modal` component
- **UTXOManagementModal**: refactor to `Modal`; embed Create Colored UTXOs as step 2; channel-style filter tabs; Withdraw-style fee selector; blue info banner
- **IssueAssetModal**: refactor to `Modal`; blue info banner; consistent inputs; `Plus` icon on CTA
- **NotificationSystem**: Clear All matches Manage UTXOs style with `MailOpen` icon; 20px gap before close
- **Toolbar**: replace `AlertTriangle` with `Loader2 animate-spin` in node-switching banner
- **SkipMnemonicWarningModal**: remove `?` from title; Skip Anyway red CTA first; Save Recovery Phrase outline second; button styles match Logout
- **MnemonicDisplay**: remove "Important" title; `AlertTriangle` icon; button styles match Logout
- **wallet-remote**: Test Connection button style matches Logout button

## Test plan

- [ ] Liquidity > Your Channels: Bitcoin tab icon is gray when unselected
- [ ] Deposit modal (non-BTC asset): address auto-generates, Finish CTA visible immediately
- [ ] KaleidoMind > Start your brain: model dropdown uses shared Select style
- [ ] Support > Troubleshooting: Back and View Solutions buttons are gray style
- [ ] Peer Management modal: matches standard modal style
- [ ] UTXO Management modal: filter tabs, Create step embedded as step 2, fee selector, blue banner
- [ ] Issue Asset modal: standard modal style, blue banner, Plus icon on CTA
- [ ] Notifications panel: Clear All has MailOpen icon and outline style; 20px gap to X
- [ ] Node switching banner: shows spinner instead of alert triangle
- [ ] Skip Recovery Phrase modal: no `?` in title, red Skip Anyway first, white-outline Save second
- [ ] Mnemonic display: no "Important" label, alert triangle icon, button styles match Logout
- [ ] wallet-remote: Test Connection button matches Logout style

🤖 Generated with [Claude Code](https://claude.com/claude-code)