### PR TITLE
Release v0.5.0 (retag) — promote dev to main

### DIFF
--- a/.github/workflows/build-mind-assets.yml
+++ b/.github/workflows/build-mind-assets.yml
@@ -32,10 +32,12 @@ jobs:
           - runner: ubuntu-22.04
             platform: linux
             arch: x64
-          # Built natively on a Windows runner. @qvac engines bundle their
-          # win32-x64 `.bare` prebuilds in-package (not as os/cpu-split optional
-          # deps), so NPM_OS/NPM_CPU don't gate them — a native runner also
-          # grabs the correct node.exe via fetchNode().
+          # Built natively on a Windows runner (grabs the correct node.exe via
+          # fetchNode()). @qvac engines bundle their win32-x64 `.bare` prebuilds
+          # in-package, but `bare-runtime` IS an os/cpu-split optional dep — the
+          # bundle script normalizes NPM_OS 'win' → npm's 'win32' so npm doesn't
+          # silently skip bare-runtime-win32-x64, and fails the build if it's
+          # missing anyway.
           - runner: windows-latest
             platform: win
             arch: x64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-## [Version 0.5.0] - 2026-07-08
+## [Version 0.5.0] - 2026-07-10
 
 > ⚠️ **KaleidoMind is experimental.** The on-device agent and chat-based trading are an early preview — expect rough edges, occasional incorrect responses, and changing behavior between releases. Always review the confirmation details before approving any spend.
 
 ### 🚀 Features
-- **KaleidoMind — on-device AI agent (experimental)**: A local, private assistant that runs entirely on-device via the QVAC engine. Chat with your wallet and node in natural language — no data leaves the machine. Bundled with the app and downloaded on first enable (provider + MCP runtime, `mind-assets-v0.7.0`), now including a **Windows (win-x64)** agent runtime alongside macOS and Linux
+- **KaleidoMind — on-device AI agent (experimental)**: A local, private assistant that runs entirely on-device via the QVAC engine. Chat with your wallet and node in natural language — no data leaves the machine. Bundled with the app and downloaded on first enable (provider + MCP runtime, `mind-assets-v0.7.1`), now including a **Windows (win-x64)** agent runtime alongside macOS and Linux
 - **Trade by chat**: Ask "buy 1 USDT on KaleidoSwap" and the agent quotes the maker and runs the full atomic swap (quote → init → whitelist → execute) behind a single confirmation gate showing the real numbers
 - **Buy a Lightning channel by chat**: Order inbound BTC liquidity or a new RGB asset channel (USDT/XAUT) pre-loaded via the LSP, as a one-confirmation flow
 - **Agent tab (autonomy)**: Schedule the agent to run optimizer tasks (portfolio, DCA-style) with risk limits and a dry-run default; review recent runs and costs
@@ -21,11 +21,12 @@
 - **Redesigned Deposit & Withdraw modals**: Cleaner deposit/withdraw modals with an updated global asset logo treatment
 - **Redesigned buy-channel flow**: Cleaner channel summary and payment-review UI with richer states and clearer cost breakdowns, plus Market Maker navigation polish
 - **General UI polish**: Refreshed splash screen branding, channel cards, DCA and Limit Order surfaces, buttons, modals, support modal, and notification panel
+- **Modal & control standardization**: Refactored the Peer Management, UTXO Management, and Issue Asset modals onto the shared `Modal` component with consistent inputs, filter tabs, fee selectors, and info banners; embedded Create Colored UTXOs as a step within UTXO management; swapped native `<select>`s for the shared `Select`; standardized the notification "Clear All", Skip Recovery Phrase, mnemonic display, and Test Connection button treatments; and replaced the node-switching alert icon with a spinner
 - **Consolidated Maker & LSP configuration**: Unified Maker and LSP URL configuration in Settings
 - **"Max via Lightning" deposit**: The Lightning deposit max now reflects the maximum HTLC limit across channels
 - **Onboarding readability**: Improved recovery-phrase readability during onboarding
 - **KaleidoMind polish**: Styled the model pickers, fixed a modal race condition, and restyled the start screen
-- **Mind runtime v0.7.0**: Updated the bundled provider (`@kaleidorg/mind-provider ^0.6.3`) and MCP (`kaleido-mcp ^0.2.1`) so chat trading and the stop button work end to end
+- **Mind runtime v0.7.1**: Updated the bundled provider (`@kaleidorg/mind-provider ^0.6.3`) and MCP (`kaleido-mcp ^0.2.1`) so chat trading and the stop button work end to end; the win-x64 runtime now ships the Bare runtime binary
 - **SDK migration**: Moved to `kaleido-sdk ^0.1.11` (BitcoinNetwork node/api split, TransferKind enum, refresh defaults)
 - **Removed Auto Time-Lock**: Dropped the Auto Time-Lock setting to simplify node configuration
 
@@ -40,9 +41,11 @@
 - **Expanded channel card**: Restored the expanded channel card with BTC/RGB icons
 - **No false restart prompt**: Settings no longer shows a spurious "restart required" prompt
 - **Trade page & dashboard fixes**: Assorted fixes across the trade page and dashboard
+- **KaleidoMind won't start on Windows**: The win-x64 agent runtime was published without its Bare runtime binary (`bare-runtime-win32-x64`), so QVAC aborted at model load with "Could not load the Bare runtime binary for win32-x64". The bundle now installs the platform package (npm's `--os` needs `win32`, not `win`) and the CI build fails outright if any platform runtime is missing
+- **BTC deposit/withdrawal history was empty**: History filtered on a `transaction_type` of `User`, which the node's enum never emits; it now classifies on-chain movements by excluding RGB transaction types and derives direction from the net sent/received amount, and shows the loader while either query is still in flight
 
 ### 🏗️ Infrastructure
-- **Windows KaleidoMind runtime build**: The `build-mind-assets` CI workflow now builds and publishes the `win-x64` agent runtime tarball, fixing the 404 Windows users hit on first enable. Includes Windows-specific bundling fixes: resolving `npm.cmd`, running npm via shell (Node 24 `.cmd`-spawn EINVAL), extracting the Node `.zip` with System32 `bsdtar`, and a `sha256sum`/`shasum -a 256` checksum fallback
+- **Windows KaleidoMind runtime build**: The `build-mind-assets` CI workflow now builds and publishes the `win-x64` agent runtime tarball, fixing the 404 Windows users hit on first enable. Includes Windows-specific bundling fixes: resolving `npm.cmd`, running npm via shell (Node 24 `.cmd`-spawn EINVAL), extracting the Node `.zip` with System32 `bsdtar`, a `sha256sum`/`shasum -a 256` checksum fallback, normalizing npm's `--os` to `win32` so the Bare runtime platform package is installed, and a build-time guard that fails if any platform runtime package is missing
 
 ## [Version 0.4.0] - 2026-04-15
 

--- a/src-tauri/scripts/prepare-mind-bundle.mjs
+++ b/src-tauri/scripts/prepare-mind-bundle.mjs
@@ -115,6 +115,14 @@ function reset() {
   writeFileSync(join(out, '.gitkeep'), '')
 }
 
+// npm matches --os against packages' `"os"` fields, which use Node's
+// process.platform values — on Windows that's `win32`, NOT the `win` shorthand
+// the tarball/Node-dist naming uses. Passing --os=win makes npm silently skip
+// every win32-gated optional dep (bare-runtime-win32-x64 → "Could not load the
+// Bare runtime binary" at model load), so normalize it here.
+const npmOs = process.env.NPM_OS === 'win' ? 'win32' : process.env.NPM_OS
+const npmCpu = process.env.NPM_CPU
+
 // Install npm `deps` into `<out>/<name>` as a self-contained, prod-only tree.
 // npm's default hoisted layout puts each dep's own files at
 // `<name>/node_modules/<pkg>/…`, which is what main.rs probes for.
@@ -132,9 +140,30 @@ function installFromNpm(name, deps) {
   // NPM_OS / NPM_CPU force npm to fetch the TARGET platform's prebuilt native
   // packages (e.g. the macOS runner is arm64 but also builds the x64 target).
   const npmArgs = ['install', '--omit=dev', '--no-audit', '--no-fund']
-  if (process.env.NPM_OS) npmArgs.push(`--os=${process.env.NPM_OS}`)
-  if (process.env.NPM_CPU) npmArgs.push(`--cpu=${process.env.NPM_CPU}`)
+  if (npmOs) npmArgs.push(`--os=${npmOs}`)
+  if (npmCpu) npmArgs.push(`--cpu=${npmCpu}`)
   run(NPM, npmArgs, dir, { shell: isWin })
+}
+
+// os/cpu-split optional deps fail SILENTLY when the platform filter mismatches
+// (that's how the win32 Bare runtime went missing). For each such runtime the
+// tree relies on, require the platform package outright — a loud build failure
+// beats shipping a bundle that aborts at model load on users' machines.
+function assertPlatformRuntimes(name) {
+  const nm = join(out, name, 'node_modules')
+  const os = npmOs ?? process.platform
+  const cpu = npmCpu ?? process.arch
+  for (const runtime of ['bare-runtime']) {
+    if (!existsSync(join(nm, runtime))) continue // not in this tree at all
+    const plat = join(nm, `${runtime}-${os}-${cpu}`)
+    if (!existsSync(plat)) {
+      throw new Error(
+        `${name}: ${runtime} is installed but its platform package ` +
+          `${runtime}-${os}-${cpu} is missing from node_modules — npm's ` +
+          `--os/--cpu filter likely skipped it; the bundle would crash at runtime`
+      )
+    }
+  }
 }
 
 // Delete the unused @qvac engines (DROP_ENGINES) and unused top-level native
@@ -235,6 +264,7 @@ installFromNpm('provider', {
   '@kaleidorg/mind-provider': PROVIDER_VERSION,
   '@qvac/sdk': QVAC_VERSION,
 })
+assertPlatformRuntimes('provider')
 pruneEngines('provider')
 // After pruning engines, the default worker would crash importing them — swap in
 // a worker that registers only the LLM plugin we kept.

--- a/src-tauri/src/mind_runtime.rs
+++ b/src-tauri/src/mind_runtime.rs
@@ -17,7 +17,7 @@ use tauri::{AppHandle, Emitter, Manager};
 
 /// GitHub release tag the agent tarballs live under. Bump when the agent
 /// (provider/mcp/@qvac) version changes and new assets are published.
-const ASSETS_TAG: &str = "mind-assets-v0.7.0";
+const ASSETS_TAG: &str = "mind-assets-v0.7.1";
 const ASSETS_REPO: &str = "kaleidoswap/desktop-app";
 const RUNTIME_EVENT: &str = "mind-runtime";
 

--- a/src/components/ChannelCard/index.tsx
+++ b/src/components/ChannelCard/index.tsx
@@ -374,7 +374,13 @@ export const ChannelCard: React.FC<ChannelCardProps> = ({
 
             {/* RGB badge */}
             {isRgbChannel && asset && (
-              <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded-full bg-purple-900/30 text-purple-300 border border-purple-800/30">
+              <span
+                className={`flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded-full ${
+                  asset.ticker === 'USDT'
+                    ? 'bg-[#26A17B]/10 text-[#26A17B] border border-[#26A17B]/30'
+                    : 'bg-purple-900/30 text-purple-300 border border-purple-800/30'
+                }`}
+              >
                 <AssetIcon className="h-2.5 w-2.5" ticker={asset.ticker} />
                 {asset.ticker}
               </span>
@@ -455,36 +461,42 @@ export const ChannelCard: React.FC<ChannelCardProps> = ({
             const inPct = total > 0 ? (inb / total) * 100 : 50
             return (
               <div className="rounded-lg bg-surface-overlay/40 p-2.5 border border-purple-800/20">
-                {/* Section header: asset + amounts */}
-                <div className="flex items-center justify-between gap-2 mb-1.5">
-                  <div className="flex items-center gap-1.5 text-[11px] text-lime-300/90">
+                {/* Section header: outbound | logo+ticker | inbound */}
+                <div className="grid grid-cols-3 items-center mb-1.5">
+                  <span className="flex items-center gap-0.5 text-[10px] font-mono text-[#9365FF]">
+                    <ArrowUpRight className="h-3 w-3" />
+                    {formatAssetAmount(out)}
+                  </span>
+                  <span
+                    className="flex items-center justify-center gap-1 text-[11px] font-semibold"
+                    style={asset.ticker === 'USDT' ? { color: '#26A17B' } : {}}
+                  >
                     <AssetIcon className="h-3.5 w-3.5" ticker={asset.ticker} />
-                    <span className="font-semibold">{asset.ticker}</span>
-                  </div>
-                  <div className="flex items-center gap-1.5 text-[10px] font-mono">
-                    <span className="flex items-center gap-0.5 text-lime-300">
-                      <ArrowUpRight className="h-3 w-3" />
-                      {formatAssetAmount(out)}
+                    <span
+                      className={
+                        asset.ticker === 'USDT' ? '' : 'text-content-secondary'
+                      }
+                    >
+                      {asset.ticker}
                     </span>
-                    <span className="text-content-tertiary/40">/</span>
-                    <span className="flex items-center gap-0.5 text-emerald-400">
-                      <ArrowDownRight className="h-3 w-3" />
-                      {formatAssetAmount(inb)}
-                    </span>
-                  </div>
+                  </span>
+                  <span className="flex items-center justify-end gap-0.5 text-[10px] font-mono text-emerald-400">
+                    {formatAssetAmount(inb)}
+                    <ArrowDownRight className="h-3 w-3" />
+                  </span>
                 </div>
                 <div className="relative h-2.5 bg-surface-overlay rounded-full overflow-hidden">
                   <div
-                    className="absolute left-0 top-0 h-full bg-lime-300 rounded-l-full"
+                    className="absolute left-0 top-0 h-full bg-[#9365FF] rounded-l-full"
                     style={{ width: `${outPct}%` }}
                   />
                   <div
-                    className="absolute right-0 top-0 h-full bg-emerald-600 rounded-r-full"
+                    className="absolute right-0 top-0 h-full bg-emerald-500 rounded-r-full"
                     style={{ width: `${inPct}%` }}
                   />
                 </div>
                 <div className="flex justify-between text-[8px] font-semibold uppercase tracking-wider mt-1">
-                  <span className="text-lime-300/70">
+                  <span className="text-[#9365FF]/70">
                     {t('channelCard.labels.outbound')}
                   </span>
                   <span className="text-emerald-400/70">

--- a/src/components/IssueAssetModal/index.tsx
+++ b/src/components/IssueAssetModal/index.tsx
@@ -1,16 +1,12 @@
-import { X } from 'lucide-react'
+import { Plus, Loader, Info, X } from 'lucide-react'
 import React, { useState, useMemo } from 'react'
-import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'react-toastify'
 
-import {
-  getModalPortalTarget,
-  getModalPositionClass,
-} from '../../helpers/modalPortal'
 import { useUtxoErrorHandler } from '../../hooks/useUtxoErrorHandler'
 import { nodeApi } from '../../slices/nodeApi/nodeApi.slice'
 import { CreateUTXOModal } from '../CreateUTXOModal'
+import { Modal } from '../ui/Modal'
 
 interface IssueAssetModalProps {
   onClose: () => void
@@ -33,34 +29,22 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
 
   const [issueAsset] = nodeApi.endpoints.issueNiaAsset.useMutation()
 
-  // Calculate the actual amount that will be issued with decimal places
   const actualAmount = useMemo(() => {
     if (
       !amount ||
       isNaN(Number(amount)) ||
       !precision ||
       isNaN(Number(precision))
-    ) {
+    )
       return '0'
-    }
-
-    // Convert to base units (add zeros based on precision)
-    const baseAmount = Number(amount) * Math.pow(10, Number(precision))
-    return baseAmount.toString()
+    return (Number(amount) * Math.pow(10, Number(precision))).toString()
   }, [amount, precision])
 
-  // Format preview amount with decimal places
   const previewAmount = useMemo(() => {
-    if (!amount || isNaN(Number(amount))) {
-      return '0'
-    }
-
-    // Clamp precision between 0 and 10
+    if (!amount || isNaN(Number(amount))) return '0'
     let safePrecision = Number(precision)
     if (isNaN(safePrecision) || safePrecision < 0) safePrecision = 0
     if (safePrecision > 10) safePrecision = 10
-
-    // Display with appropriate decimal places
     return Number(amount).toFixed(safePrecision)
   }, [amount, precision])
 
@@ -76,22 +60,18 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
-
     try {
       await issueAssetOperation()
       toast.success(t('issueAssetModal.success'))
       onSuccess()
       onClose()
     } catch (error: any) {
-      // Check if it's a UTXO-related error
       const wasHandled = handleApiError(
         error,
         'issuance',
         0,
         issueAssetOperation
       )
-
-      // Only show toast for errors that weren't handled by the UTXO modal
       if (!wasHandled) {
         toast.error(
           error?.data?.error ||
@@ -105,32 +85,36 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
     }
   }
 
-  const pos = getModalPositionClass()
+  const inputClass =
+    'w-full bg-surface-overlay/50 text-white px-4 py-2.5 rounded-lg border border-border-default ' +
+    'focus:border-primary/50 focus:ring-1 focus:ring-primary/20 focus:outline-none text-sm placeholder-content-tertiary'
 
-  return createPortal(
+  return (
     <>
-      <div
-        className={`${pos} inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50`}
-        onClick={onClose}
-      >
-        <div
-          className="bg-surface-overlay rounded-xl border border-border-default p-6 w-full max-w-md"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div className="flex justify-between items-center mb-6">
-            <h2 className="text-xl font-bold text-white">
+      <Modal isOpen onClose={onClose} size="sm">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-divider/10">
+          <div className="flex items-center gap-3">
+            <Plus className="w-5 h-5 text-primary" />
+            <h3 className="text-xl font-semibold text-white">
               {t('issueAssetModal.title')}
-            </h2>
-            <button
-              className="p-2 hover:bg-surface-high rounded-lg transition-colors"
-              onClick={onClose}
-            >
-              <X className="w-5 h-5 text-content-secondary" />
-            </button>
+            </h3>
           </div>
+          <button
+            aria-label="Close modal"
+            className="p-2 rounded-full hover:bg-surface-overlay text-content-secondary hover:text-white transition-colors"
+            onClick={onClose}
+          >
+            <X size={20} />
+          </button>
+        </div>
 
-          <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4 mb-6">
-            <p className="text-blue-400 text-sm">{t('issueAssetModal.note')}</p>
+        {/* Body */}
+        <div className="p-6 space-y-5">
+          {/* Info banner */}
+          <div className="flex items-start gap-3 rounded-lg bg-blue-500/10 border border-blue-500/20 p-4">
+            <Info className="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-blue-300">{t('issueAssetModal.note')}</p>
           </div>
 
           <form className="space-y-4" onSubmit={handleSubmit}>
@@ -139,7 +123,7 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
                 {t('issueAssetModal.tickerLabel')}
               </label>
               <input
-                className="w-full bg-surface-base border border-border-default rounded-lg px-4 py-2 text-white"
+                className={inputClass}
                 maxLength={5}
                 onChange={(e) => setTicker(e.target.value.toUpperCase())}
                 placeholder={t('issueAssetModal.tickerPlaceholder')}
@@ -154,7 +138,7 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
                 {t('issueAssetModal.nameLabel')}
               </label>
               <input
-                className="w-full bg-surface-base border border-border-default rounded-lg px-4 py-2 text-white"
+                className={inputClass}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={t('issueAssetModal.namePlaceholder')}
                 required
@@ -168,7 +152,7 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
                 {t('issueAssetModal.amountLabel')}
               </label>
               <input
-                className="w-full bg-surface-base border border-border-default rounded-lg px-4 py-2 text-white"
+                className={inputClass}
                 min="0"
                 onChange={(e) => setAmount(e.target.value)}
                 placeholder={t('issueAssetModal.amountPlaceholder')}
@@ -183,13 +167,11 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
                 {t('issueAssetModal.precisionLabel')}
               </label>
               <input
-                className="w-full bg-surface-base border border-border-default rounded-lg px-4 py-2 text-white"
+                className={inputClass}
                 max="18"
                 min="0"
                 onChange={(e) => {
-                  // removing fraction inputs
-                  const val = e.target.value
-                  const floored = Math.floor(Number(val))
+                  const floored = Math.floor(Number(e.target.value))
                   setPrecision(String(floored))
                 }}
                 placeholder={t('issueAssetModal.precisionPlaceholder')}
@@ -207,27 +189,32 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
             </div>
 
             {amount && (
-              <p className="mt-2 text-sm text-content-secondary">
+              <p className="text-sm text-content-secondary">
                 {t('issueAssetModal.previewPrefix')}{' '}
                 <span className="text-white font-medium">{previewAmount}</span>
               </p>
             )}
+
             <button
-              className="w-full px-6 py-3 bg-primary hover:bg-primary-emphasis
-                       text-primary-foreground rounded-lg font-medium transition-colors
-                       disabled:opacity-60 disabled:cursor-not-allowed"
+              className="w-full px-4 py-2.5 bg-primary hover:bg-primary-emphasis
+                       text-primary-foreground rounded-lg text-sm font-semibold transition-colors
+                       disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               disabled={isLoading}
               type="submit"
             >
+              {isLoading ? (
+                <Loader className="w-4 h-4 animate-spin" />
+              ) : (
+                <Plus className="w-4 h-4" />
+              )}
               {isLoading
                 ? t('issueAssetModal.submitting')
                 : t('issueAssetModal.submit')}
             </button>
           </form>
         </div>
-      </div>
+      </Modal>
 
-      {/* UTXO Modal for handling UTXO-related errors */}
       <CreateUTXOModal
         channelCapacity={utxoModalProps.channelCapacity}
         error={utxoModalProps.error}
@@ -237,7 +224,6 @@ export const IssueAssetModal: React.FC<IssueAssetModalProps> = ({
         operationType={utxoModalProps.operationType}
         retryFunction={utxoModalProps.retryFunction}
       />
-    </>,
-    getModalPortalTarget()
+    </>
   )
 }

--- a/src/components/Layout/Modal/Deposit/Step2.tsx
+++ b/src/components/Layout/Modal/Deposit/Step2.tsx
@@ -146,6 +146,12 @@ export const Step2 = ({ assetId, onBack, onClose, onNext }: Props) => {
     }
   }, [isBtc])
 
+  // Auto-generate address on mount for non-BTC flows
+  useEffect(() => {
+    if (isBtc) return
+    generateAddress()
+  }, [])
+
   // When BTC amount changes, regenerate LN invoice with new amount
   useEffect(() => {
     if (!isBtc) return
@@ -1235,17 +1241,13 @@ export const Step2 = ({ assetId, onBack, onClose, onNext }: Props) => {
             className="px-4 py-2 bg-primary hover:bg-primary-emphasis disabled:opacity-50 disabled:cursor-not-allowed
                      text-primary-foreground rounded-lg transition-colors flex items-center gap-1.5 text-sm font-semibold"
             disabled={loading}
-            onClick={address ? onNext : generateAddress}
+            onClick={onNext}
           >
             {loading ? (
               <Loader className="w-4 h-4 animate-spin" />
             ) : (
               <>
-                <span>
-                  {address
-                    ? t('depositModal.common.finish')
-                    : t('depositModal.step2.actions.generateAddressCta')}
-                </span>
+                <span>{t('depositModal.common.finish')}</span>
                 <ArrowRight className="w-3.5 h-3.5" />
               </>
             )}

--- a/src/components/MnemonicDisplay/index.tsx
+++ b/src/components/MnemonicDisplay/index.tsx
@@ -1,6 +1,6 @@
 import {
   Copy,
-  AlertCircle,
+  AlertTriangle,
   ArrowRight,
   ArrowLeft,
   SkipForward,
@@ -26,11 +26,7 @@ export const MnemonicDisplay = ({
   return (
     <div className="w-full space-y-5">
       {/* Warning Message */}
-      <Alert
-        icon={<AlertCircle className="w-5 h-5" />}
-        title="Important"
-        variant="warning"
-      >
+      <Alert icon={<AlertTriangle className="w-5 h-5" />} variant="warning">
         <p className="text-sm">
           Never share your recovery phrase with anyone. Store it securely
           offline. Anyone with access to this phrase can control your wallet.
@@ -94,7 +90,7 @@ export const MnemonicDisplay = ({
       {/* Skip Button */}
       {onSkip && (
         <Button
-          className="w-full text-content-secondary border-border-default/50 hover:bg-surface-overlay/50 hover:text-content-secondary hover:border-border-default"
+          className="w-full border-white/30 hover:border-white/50 bg-transparent hover:bg-white/5 text-white"
           icon={<SkipForward className="w-4 h-4" />}
           onClick={onSkip}
           size="md"

--- a/src/components/NotificationSystem/index.tsx
+++ b/src/components/NotificationSystem/index.tsx
@@ -5,6 +5,7 @@ import {
   X,
   Bell,
   Download,
+  MailOpen,
 } from 'lucide-react'
 import React, { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -247,11 +248,14 @@ const NotificationPanel: React.FC<{
             <Bell className="w-5 h-5 text-primary" />
             <h2 className="text-lg font-semibold text-white">Notifications</h2>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-5">
             <button
-              className="text-sm text-content-secondary hover:text-white"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border
+                         border-white/30 hover:border-white/50 bg-transparent hover:bg-surface-high/50
+                         text-white transition-colors"
               onClick={onClearAll}
             >
+              <MailOpen className="w-4 h-4" />
               Clear all
             </button>
             <button

--- a/src/components/PeerManagementModal/index.tsx
+++ b/src/components/PeerManagementModal/index.tsx
@@ -1,14 +1,10 @@
 import { Users, Plus, Loader, X, Link as LinkIcon, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { createPortal } from 'react-dom'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'react-toastify'
 
-import {
-  getModalPortalTarget,
-  getModalPositionClass,
-} from '../../helpers/modalPortal'
+import { Modal } from '../ui/Modal'
 import { nodeApi } from '../../slices/nodeApi/nodeApi.slice'
 
 interface PeerManagementModalProps {
@@ -63,56 +59,46 @@ export const PeerManagementModal = ({ onClose }: PeerManagementModalProps) => {
     }
   }
 
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      onClose()
-    }
-  }
-
-  const pos = getModalPositionClass()
-
-  return createPortal(
-    <div
-      className={`${pos} inset-0 bg-black/50 backdrop-blur-sm flex items-start justify-center z-50 pt-20`}
-      onMouseDown={handleBackdropClick}
-    >
-      <div className="bg-surface-base rounded-2xl border border-border-subtle p-6 max-w-2xl w-full m-4 max-h-[calc(100vh-120px)] overflow-y-auto">
-        <div className="flex justify-between items-center mb-6">
-          <div className="flex items-center gap-3">
-            <Users className="w-6 h-6 text-blue-500" />
-            <h2 className="text-2xl font-bold text-white">
-              {t('peerManagement.title')}
-            </h2>
-          </div>
-          <button
-            className="text-content-secondary hover:text-white transition-colors"
-            onClick={onClose}
-          >
-            <X className="w-5 h-5" />
-          </button>
+  return (
+    <Modal isOpen onClose={onClose} size="md">
+      <div className="flex items-center justify-between p-4 border-b border-divider/10">
+        <div className="flex items-center gap-3">
+          <Users className="w-5 h-5 text-primary" />
+          <h3 className="text-xl font-semibold text-white">
+            {t('peerManagement.title')}
+          </h3>
         </div>
+        <button
+          aria-label="Close modal"
+          className="p-2 rounded-full hover:bg-surface-overlay text-content-secondary hover:text-white transition-colors"
+          onClick={onClose}
+        >
+          <X size={20} />
+        </button>
+      </div>
 
+      <div className="p-6 space-y-6">
         {showConnectForm ? (
-          <form className="mb-6" onSubmit={handleSubmit(handleConnect)}>
+          <form onSubmit={handleSubmit(handleConnect)}>
             <div className="flex gap-3">
               <input
                 {...register('peerAddress')}
-                className="flex-1 bg-surface-overlay border border-border-default rounded-xl px-4 py-3 text-white
-                         placeholder-slate-500 focus:outline-none focus:border-blue-500"
+                className="flex-1 bg-surface-overlay border border-border-default rounded-lg px-4 py-2.5 text-sm text-white
+                         placeholder-content-tertiary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20"
                 placeholder={t('peerManagement.peerPlaceholder')}
                 type="text"
               />
               <button
                 className="px-4 py-2 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-lg
-                         font-medium transition-colors flex items-center gap-2"
+                         text-sm font-medium transition-colors flex items-center gap-2"
                 type="submit"
               >
                 <LinkIcon className="w-4 h-4" />
                 {t('peerManagement.connect')}
               </button>
               <button
-                className="px-4 py-2 bg-surface-overlay hover:bg-surface-high text-content-secondary
-                         rounded-lg font-medium transition-colors"
+                className="px-4 py-2 text-content-secondary hover:text-white hover:bg-surface-overlay/50
+                         rounded-lg text-sm font-medium transition-colors"
                 onClick={() => setShowConnectForm(false)}
                 type="button"
               >
@@ -122,25 +108,25 @@ export const PeerManagementModal = ({ onClose }: PeerManagementModalProps) => {
           </form>
         ) : (
           <button
-            className="w-full mb-6 px-4 py-3 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-lg
-                     font-medium transition-colors flex items-center justify-center gap-2"
+            className="w-full px-4 py-2.5 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-lg
+                     text-sm font-medium transition-colors flex items-center justify-center gap-2"
             onClick={() => setShowConnectForm(true)}
           >
-            <Plus className="w-5 h-5" />
+            <Plus className="w-4 h-4" />
             {t('peerManagement.connectToPeer')}
           </button>
         )}
 
         {isLoading ? (
           <div className="flex items-center justify-center py-8">
-            <Loader className="w-6 h-6 animate-spin text-blue-500" />
+            <Loader className="w-5 h-5 animate-spin text-primary" />
           </div>
         ) : peersData?.peers && peersData.peers.length > 0 ? (
           <div className="space-y-3">
             {peersData.peers.map((peer: any) => (
               <div
-                className="bg-surface-overlay/50 rounded-xl border border-border-default p-4
-                         flex items-center gap-3 justify-between group hover:border-red-500/20 hover:bg-red-500/5"
+                className="bg-surface-overlay/50 rounded-lg border border-border-default p-4
+                         flex items-center gap-3 justify-between group hover:border-red-500/20 hover:bg-red-500/5 transition-colors"
                 key={peer.pubkey}
               >
                 <div className="w-8 h-8 rounded-full bg-surface-high flex items-center justify-center flex-shrink-0 border border-border-default/60">
@@ -169,12 +155,11 @@ export const PeerManagementModal = ({ onClose }: PeerManagementModalProps) => {
             ))}
           </div>
         ) : (
-          <div className="text-center py-8 text-content-secondary">
+          <div className="text-center py-8 text-content-secondary text-sm">
             {t('peerManagement.noPeers')}
           </div>
         )}
       </div>
-    </div>,
-    getModalPortalTarget()
+    </Modal>
   )
 }

--- a/src/components/SkipMnemonicWarningModal/index.tsx
+++ b/src/components/SkipMnemonicWarningModal/index.tsx
@@ -21,9 +21,7 @@ export const SkipMnemonicWarningModal = ({
           <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-status-danger/10 border border-status-danger/20 shrink-0">
             <AlertTriangle className="w-5 h-5 text-status-danger" />
           </div>
-          <h2 className="text-xl font-bold text-white">
-            Skip Recovery Phrase?
-          </h2>
+          <h2 className="text-xl font-bold text-white">Skip Recovery Phrase</h2>
         </div>
 
         {/* Warning Content */}
@@ -48,20 +46,20 @@ export const SkipMnemonicWarningModal = ({
         {/* Action Buttons */}
         <div className="flex flex-col gap-2.5">
           <Button
-            className="w-full"
-            onClick={onCancel}
-            size="lg"
-            variant="primary"
-          >
-            Go Back and Save Recovery Phrase
-          </Button>
-          <Button
-            className="w-full border-status-danger/30 text-status-danger hover:bg-status-danger/10 hover:border-status-danger/50"
+            className="w-full bg-red-600/80 hover:bg-red-600 text-white border-transparent"
             onClick={onConfirm}
             size="lg"
             variant="outline"
           >
             Skip Anyway
+          </Button>
+          <Button
+            className="w-full border-white/30 hover:border-white/50 bg-transparent hover:bg-white/5 text-white"
+            onClick={onCancel}
+            size="lg"
+            variant="outline"
+          >
+            Save Recovery Phrase
           </Button>
         </div>
 

--- a/src/components/SupportModal/index.tsx
+++ b/src/components/SupportModal/index.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   AlertTriangle,
   CheckCircle,
+  ChevronDown,
   ChevronRight,
 } from 'lucide-react'
 import { useState } from 'react'
@@ -205,7 +206,7 @@ export const SupportModal = ({ isOpen, onClose }: SupportModalProps) => {
                   className="bg-surface-overlay/50 border border-divider/20 rounded-xl p-4 cursor-pointer hover:bg-surface-elevated/30 transition-colors duration-200 group"
                   onClick={() =>
                     openExternalLink(
-                      'https://github.com/kaleidoswap/desktop-app'
+                      'https://github.com/kaleidoswap/desktop-app/issues'
                     )
                   }
                 >
@@ -252,10 +253,10 @@ export const SupportModal = ({ isOpen, onClose }: SupportModalProps) => {
           {activeSection === 'troubleshoot' && (
             <div className="space-y-5">
               <button
-                className="flex items-center gap-2 text-primary hover:underline mb-4"
+                className="px-3 py-2 text-content-secondary hover:text-white transition-colors flex items-center gap-1.5 hover:bg-surface-overlay/50 rounded-lg text-sm mb-4"
                 onClick={goBack}
               >
-                <ChevronRight className="w-4 h-4 rotate-180" />
+                <ChevronRight className="w-3.5 h-3.5 rotate-180" />
                 <span>{t('supportModal.backToSupport')}</span>
               </button>
 
@@ -284,20 +285,21 @@ export const SupportModal = ({ isOpen, onClose }: SupportModalProps) => {
                           </p>
                         </div>
                       </div>
-                      <button className="p-1 text-content-secondary hover:text-white transition-colors">
-                        {expandedIssue === index ? (
+                      {expandedIssue === index ? (
+                        <button className="p-1 text-content-secondary hover:text-white transition-colors">
                           <X className="w-5 h-5" />
-                        ) : (
-                          <span className="text-primary">
-                            {t('supportModal.viewSolutions')}
-                          </span>
-                        )}
-                      </button>
+                        </button>
+                      ) : (
+                        <button className="px-3 py-2 text-content-secondary hover:text-white transition-colors flex items-center gap-1.5 hover:bg-surface-overlay/50 rounded-lg text-sm">
+                          <span>{t('supportModal.viewSolutions')}</span>
+                          <ChevronDown className="w-3.5 h-3.5" />
+                        </button>
+                      )}
                     </div>
 
                     {expandedIssue === index && (
                       <div className="px-5 pb-5 pt-2 border-t border-divider/20 bg-surface-base/30">
-                        <h4 className="text-sm font-semibold text-primary mb-3">
+                        <h4 className="text-sm font-semibold text-white mb-3">
                           {t('supportModal.solutions')}
                         </h4>
                         <ul className="space-y-2">

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -1051,7 +1051,7 @@ const CopyField = ({ label, value }: { label: string; value: string }) => {
       <label className="text-xs font-medium text-content-secondary uppercase tracking-wider">
         {label}
       </label>
-      <div className="mt-1.5 flex items-center gap-2 px-3 py-2 rounded-lg border border-border-default/50 bg-surface-overlay/30 group">
+      <div className="mt-1.5 flex items-center gap-2 px-3 py-2 rounded-lg border border-border-default/50 bg-surface-base group">
         <span className="flex-1 text-sm text-white break-all font-mono">
           {value}
         </span>
@@ -1089,7 +1089,7 @@ const AccordionSection = ({
         border rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary/20
         ${
           isOpen
-            ? 'border-primary bg-surface-elevated/60 shadow-[0_0_10px_rgba(21,233,154,0.15)] rounded-b-none'
+            ? 'border-border-default/50 bg-surface-overlay/50 rounded-b-none'
             : 'border-border-default/50 bg-surface-overlay/30 hover:bg-surface-overlay/50 hover:border-border-default/70'
         }`}
       onClick={onToggle}
@@ -1101,7 +1101,7 @@ const AccordionSection = ({
       />
     </button>
     {isOpen && (
-      <div className="p-4 border border-t-0 border-primary/50 rounded-b-lg bg-surface-elevated/60 space-y-3">
+      <div className="p-4 border border-t-0 border-border-default/50 rounded-b-lg bg-surface-overlay/30 space-y-3">
         {children}
       </div>
     )}
@@ -1261,7 +1261,7 @@ const NodeSelectionModalContent: React.FC<NodeSelectionModalContentProps> = ({
       {loadingState && (
         <div className="bg-primary/10 border border-primary/30 rounded-lg p-4 mb-4">
           <div className="flex items-center gap-3">
-            <AlertTriangle className="w-5 h-5 text-primary shrink-0" />
+            <Loader2 className="w-5 h-5 text-primary shrink-0 animate-spin" />
             <p className="text-primary font-medium">{loadingState.message}</p>
           </div>
         </div>

--- a/src/components/UTXOManagementModal/index.tsx
+++ b/src/components/UTXOManagementModal/index.tsx
@@ -1,17 +1,26 @@
-import { Plus, Loader, Zap, Wallet, Paintbrush } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
-import { createPortal } from 'react-dom'
-import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
-
-import { CREATEUTXOS_PATH } from '../../app/router/paths'
 import {
-  getModalPortalTarget,
-  getModalPositionClass,
-} from '../../helpers/modalPortal'
+  Plus,
+  Loader,
+  Zap,
+  Wallet,
+  Paintbrush,
+  ArrowLeft,
+  Info,
+  Database,
+  Clock,
+  Rocket,
+  Settings,
+  X,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'react-toastify'
+
 import { formatBitcoinAmount } from '../../helpers/number'
 import { nodeApi } from '../../slices/nodeApi/nodeApi.slice'
 import { getAssignmentAmount } from '../../utils/rgbUtils'
+import { Modal } from '../ui/Modal'
 
 interface UTXOManagementModalProps {
   onClose: () => void
@@ -27,12 +36,20 @@ interface UTXOSummary {
   normalCount: number
 }
 
+interface CreateFormFields {
+  num: number
+  size: number
+  fee_rate: string
+}
+
 export const UTXOManagementModal = ({
   onClose,
   bitcoinUnit,
 }: UTXOManagementModalProps) => {
-  const navigate = useNavigate()
   const { t } = useTranslation()
+  const [step, setStep] = useState<'list' | 'create'>('list')
+
+  // ── List step state ──────────────────────────────────────────────────────
   const [listUnspents, { data: unspentsData, isLoading }] =
     nodeApi.useLazyListUnspentsQuery()
 
@@ -58,11 +75,6 @@ export const UTXOManagementModal = ({
         },
       }
     }
-
-    // Separate UTXOs into:
-    // 1. Colorable (can be used for RGB assets but not yet allocated)
-    // 2. Colored (already have RGB allocations)
-    // 3. Normal (can't be used for RGB assets)
 
     const colored = unspentsData.unspents.filter(
       (u: any) =>
@@ -107,36 +119,22 @@ export const UTXOManagementModal = ({
     'all' | 'colorable' | 'colored' | 'normal'
   >('all')
 
-  const handleCreateUTXOs = () => {
-    onClose()
-    navigate(CREATEUTXOS_PATH)
-  }
-
   const getUtxoStatusLabel = (unspent: any) => {
-    if (!unspent.utxo?.colorable) {
-      return t('utxoManagement.status.normal')
-    }
-    if (unspent.rgb_allocations && unspent.rgb_allocations.length > 0) {
+    if (!unspent.utxo?.colorable) return t('utxoManagement.status.normal')
+    if (unspent.rgb_allocations && unspent.rgb_allocations.length > 0)
       return t('utxoManagement.status.colored')
-    }
     return t('utxoManagement.status.colorable')
   }
 
   const getUtxoStatusStyle = (unspent: any) => {
-    if (!unspent.utxo?.colorable) {
-      return 'bg-blue-500/20 text-blue-400'
-    }
-    if (unspent.rgb_allocations && unspent.rgb_allocations.length > 0) {
+    if (!unspent.utxo?.colorable) return 'bg-blue-500/20 text-blue-400'
+    if (unspent.rgb_allocations && unspent.rgb_allocations.length > 0)
       return 'bg-purple-500/20 text-purple-400'
-    }
     return 'bg-green-500/20 text-green-400'
   }
 
-  const UTXOCard = ({ unspent }: { unspent: any; index: number }) => (
-    <div
-      className="bg-surface-overlay/50 rounded-xl border border-border-default p-4"
-      key={unspent.utxo.outpoint}
-    >
+  const UTXOCard = ({ unspent }: { unspent: any }) => (
+    <div className="bg-surface-overlay/50 rounded-lg border border-border-default p-4">
       <div className="flex justify-between items-start mb-2">
         <div className="text-sm font-medium text-content-secondary">
           {unspent.utxo?.outpoint?.split(':')[0]}
@@ -172,12 +170,6 @@ export const UTXOManagementModal = ({
       )}
     </div>
   )
-
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      onClose()
-    }
-  }
 
   const summaryCards = [
     {
@@ -215,166 +207,421 @@ export const UTXOManagementModal = ({
     },
   ]
 
-  const pos = getModalPositionClass()
+  // ── Create step state ────────────────────────────────────────────────────
+  const [feeEstimations, setFeeEstimations] = useState({
+    fast: 3,
+    normal: 2,
+    slow: 1,
+  })
+  const [customFee, setCustomFee] = useState(1.0)
+  const [isCreating, setIsCreating] = useState(false)
 
-  return createPortal(
-    <div
-      className={`${pos} inset-0 bg-black/50 backdrop-blur-sm flex items-start justify-center z-50 pt-20`}
-      onMouseDown={handleBackdropClick}
-    >
-      <div className="bg-surface-base rounded-2xl border border-border-subtle p-6 max-w-4xl w-full m-4 max-h-[calc(100vh-120px)] overflow-y-auto">
-        <div className="flex justify-between items-center mb-6">
-          <h2 className="text-2xl font-bold text-white">
-            {t('utxoManagement.title')}
-          </h2>
-          <button
-            className="text-content-secondary hover:text-white transition-colors"
-            onClick={onClose}
-          >
-            ✕
-          </button>
+  const { handleSubmit, register, watch, setValue } = useForm<CreateFormFields>(
+    {
+      defaultValues: { fee_rate: 'normal', num: 4, size: 32500 },
+    }
+  )
+
+  const feeRateOptions = [
+    {
+      icon: <Clock className="w-4 h-4" />,
+      label: t('withdrawModal.form.fees.options.slow'),
+      rate: feeEstimations.slow,
+      value: 'slow',
+    },
+    {
+      icon: <Zap className="w-4 h-4" />,
+      label: t('withdrawModal.form.fees.options.normal'),
+      rate: feeEstimations.normal,
+      value: 'normal',
+    },
+    {
+      icon: <Rocket className="w-4 h-4" />,
+      label: t('withdrawModal.form.fees.options.fast'),
+      rate: feeEstimations.fast,
+      value: 'fast',
+    },
+    {
+      icon: <Settings className="w-4 h-4" />,
+      label: t('withdrawModal.form.fees.options.custom'),
+      rate: customFee,
+      value: 'custom',
+    },
+  ]
+
+  const num = watch('num')
+  const size = watch('size')
+  const feeRate = watch('fee_rate')
+
+  const [btcBalance, btcBalanceResponse] =
+    nodeApi.endpoints.btcBalance.useLazyQuery()
+  const [createutxos] = nodeApi.useCreateUtxosMutation()
+  const [estimateFee] = nodeApi.useLazyEstimateFeeQuery()
+
+  const refreshBalance = useCallback(() => {
+    btcBalance()
+  }, [btcBalance])
+
+  useEffect(() => {
+    if (step !== 'create') return
+    const fetchFees = async () => {
+      try {
+        const [slowFee, normalFee, fastFee] = await Promise.all([
+          estimateFee({ blocks: 6 }).unwrap(),
+          estimateFee({ blocks: 3 }).unwrap(),
+          estimateFee({ blocks: 1 }).unwrap(),
+        ])
+        setFeeEstimations({
+          fast: Math.round(fastFee.fee_rate ?? 3),
+          normal: Math.round(normalFee.fee_rate ?? 2),
+          slow: Math.round(slowFee.fee_rate ?? 1),
+        })
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    fetchFees()
+    refreshBalance()
+    const intervalId = setInterval(refreshBalance, 15_000)
+    return () => clearInterval(intervalId)
+  }, [step, estimateFee, refreshBalance])
+
+  const onSubmitCreate = (data: CreateFormFields) => {
+    setIsCreating(true)
+    createutxos({
+      fee_rate: Math.round(
+        data.fee_rate === 'slow'
+          ? feeEstimations.slow
+          : data.fee_rate === 'normal'
+            ? feeEstimations.normal
+            : data.fee_rate === 'fast'
+              ? feeEstimations.fast
+              : customFee
+      ),
+      num: data.num,
+      size: data.size,
+      up_to: false,
+    }).then((res: any) => {
+      setIsCreating(false)
+      if (res.error) {
+        toast.error(res.error.data.error)
+      } else {
+        toast.success(t('createUtxos.toastSuccess'))
+        listUnspents()
+        setStep('list')
+      }
+    })
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────────
+  return (
+    <Modal isOpen onClose={onClose} size="lg">
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b border-divider/10">
+        <div className="flex items-center gap-3">
+          {step === 'create' ? (
+            <Paintbrush className="w-5 h-5 text-purple-400" />
+          ) : (
+            <Database className="w-5 h-5 text-primary" />
+          )}
+          <h3 className="text-xl font-semibold text-white">
+            {step === 'list'
+              ? t('utxoManagement.title')
+              : t('createUtxos.title')}
+          </h3>
         </div>
-
-        {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-          {summaryCards.map((card) => (
-            <div
-              className="bg-surface-overlay/50 rounded-xl border border-border-default p-4 flex flex-col"
-              key={card.key}
-            >
-              <div className="flex items-center gap-2 mb-2">
-                {card.icon}
-                <h3 className="text-lg font-medium text-white">{card.title}</h3>
-              </div>
-              <div className="flex flex-col gap-1.5 flex-1">
-                {card.bullets.map((bullet) => (
-                  <div
-                    className="flex items-center gap-2 text-sm text-content-secondary"
-                    key={bullet}
-                  >
-                    <div className={`w-2 h-2 rounded-full ${card.dotClass}`} />
-                    <span>{bullet}</span>
-                  </div>
-                ))}
-              </div>
-              <div className="mt-4 pt-3 border-t border-border-default/50">
-                <div className="text-2xl font-bold text-white">
-                  {formatBitcoinAmount(card.total, bitcoinUnit)} {bitcoinUnit}
-                </div>
-                <div className="text-sm text-content-secondary mt-0.5">
-                  {t('utxoManagement.summary.countLabel', {
-                    count: card.count,
-                  })}
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-
         <button
-          className="w-full mb-6 px-4 py-3 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-lg 
-                   font-medium transition-colors flex items-center justify-center gap-2"
-          onClick={handleCreateUTXOs}
+          aria-label="Close modal"
+          className="p-2 rounded-full hover:bg-surface-overlay text-content-secondary hover:text-white transition-colors"
+          onClick={onClose}
         >
-          <Plus className="w-5 h-5" />
-          {t('utxoManagement.actions.create')}
+          <X size={20} />
         </button>
-
-        {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <Loader className="w-6 h-6 animate-spin text-blue-500" />
-          </div>
-        ) : unspentsData?.unspents && unspentsData.unspents.length > 0 ? (
-          <div>
-            {/* Filter chips */}
-            <div className="flex items-center gap-2 mb-4 flex-wrap">
-              {(
-                [
-                  {
-                    count:
-                      colorableUtxos.length +
-                      coloredUtxos.length +
-                      normalUtxos.length,
-                    icon: null,
-                    key: 'all',
-                    label: t('utxoManagement.filter.all'),
-                  },
-                  {
-                    count: colorableUtxos.length,
-                    icon: <Zap className="w-3.5 h-3.5" />,
-                    key: 'colorable',
-                    label: t('utxoManagement.sections.colorable'),
-                  },
-                  {
-                    count: coloredUtxos.length,
-                    icon: <Paintbrush className="w-3.5 h-3.5" />,
-                    key: 'colored',
-                    label: t('utxoManagement.sections.colored'),
-                  },
-                  {
-                    count: normalUtxos.length,
-                    icon: <Wallet className="w-3.5 h-3.5" />,
-                    key: 'normal',
-                    label: t('utxoManagement.sections.normal'),
-                  },
-                ] as const
-              ).map(({ key, label, count, icon }) => (
-                <button
-                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 border
-                    ${
-                      activeFilter === key
-                        ? 'bg-white/15 border-white/30 text-white'
-                        : 'bg-white/5 border-white/10 text-content-tertiary hover:border-white/20 hover:text-content-secondary'
-                    }`}
-                  key={key}
-                  onClick={() => setActiveFilter(key)}
-                >
-                  {icon}
-                  {label}
-                  <span
-                    className={`text-xs px-1.5 py-0.5 rounded-full ${activeFilter === key ? 'bg-white/20' : 'bg-white/10'}`}
-                  >
-                    {count}
-                  </span>
-                </button>
-              ))}
-            </div>
-
-            {/* Filtered UTXO list */}
-            <div className="space-y-3">
-              {(activeFilter === 'all' || activeFilter === 'colorable') &&
-                colorableUtxos.map((unspent: any, index: number) => (
-                  <UTXOCard
-                    index={index}
-                    key={unspent.utxo?.outpoint || index}
-                    unspent={unspent}
-                  />
-                ))}
-              {(activeFilter === 'all' || activeFilter === 'colored') &&
-                coloredUtxos.map((unspent: any, index: number) => (
-                  <UTXOCard
-                    index={index}
-                    key={unspent.utxo?.outpoint || index}
-                    unspent={unspent}
-                  />
-                ))}
-              {(activeFilter === 'all' || activeFilter === 'normal') &&
-                normalUtxos.map((unspent: any, index: number) => (
-                  <UTXOCard
-                    index={index}
-                    key={unspent.utxo?.outpoint || index}
-                    unspent={unspent}
-                  />
-                ))}
-            </div>
-          </div>
-        ) : (
-          <div className="text-center py-8 text-content-secondary">
-            {t('utxoManagement.empty')}
-          </div>
-        )}
       </div>
-    </div>,
-    getModalPortalTarget()
+
+      {/* Body */}
+      {step === 'list' ? (
+        <div className="p-6 space-y-6">
+          {/* Summary Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {summaryCards.map((card) => (
+              <div
+                className="bg-surface-overlay/50 rounded-lg border border-border-default p-4 flex flex-col"
+                key={card.key}
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  {card.icon}
+                  <h3 className="text-base font-medium text-white">
+                    {card.title}
+                  </h3>
+                </div>
+                <div className="flex flex-col gap-1.5 flex-1">
+                  {card.bullets.map((bullet) => (
+                    <div
+                      className="flex items-center gap-2 text-sm text-content-secondary"
+                      key={bullet}
+                    >
+                      <div
+                        className={`w-2 h-2 rounded-full ${card.dotClass}`}
+                      />
+                      <span>{bullet}</span>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-4 pt-3 border-t border-border-default/50">
+                  <div className="text-xl font-bold text-white">
+                    {formatBitcoinAmount(card.total, bitcoinUnit)} {bitcoinUnit}
+                  </div>
+                  <div className="text-sm text-content-secondary mt-0.5">
+                    {t('utxoManagement.summary.countLabel', {
+                      count: card.count,
+                    })}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <button
+            className="w-full px-4 py-2.5 bg-primary hover:bg-primary-emphasis text-primary-foreground rounded-lg
+                     text-sm font-medium transition-colors flex items-center justify-center gap-2"
+            onClick={() => setStep('create')}
+          >
+            <Plus className="w-4 h-4" />
+            {t('utxoManagement.actions.create')}
+          </button>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader className="w-5 h-5 animate-spin text-primary" />
+            </div>
+          ) : unspentsData?.unspents && unspentsData.unspents.length > 0 ? (
+            <div>
+              {/* Filter tabs */}
+              <div className="flex gap-1 rounded-xl bg-surface-overlay/40 p-1 mb-4 w-fit">
+                {(
+                  [
+                    {
+                      count:
+                        colorableUtxos.length +
+                        coloredUtxos.length +
+                        normalUtxos.length,
+                      icon: null,
+                      key: 'all',
+                      label: t('utxoManagement.filter.all'),
+                    },
+                    {
+                      count: colorableUtxos.length,
+                      icon: <Zap className="h-3.5 w-3.5" />,
+                      key: 'colorable',
+                      label: t('utxoManagement.sections.colorable'),
+                    },
+                    {
+                      count: coloredUtxos.length,
+                      icon: <Paintbrush className="h-3.5 w-3.5" />,
+                      key: 'colored',
+                      label: t('utxoManagement.sections.colored'),
+                    },
+                    {
+                      count: normalUtxos.length,
+                      icon: <Wallet className="h-3.5 w-3.5" />,
+                      key: 'normal',
+                      label: t('utxoManagement.sections.normal'),
+                    },
+                  ] as const
+                ).map(({ key, label, count, icon }) => (
+                  <button
+                    className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:outline-none ${
+                      activeFilter === key
+                        ? 'bg-primary/15 text-primary border border-primary/30'
+                        : 'text-content-secondary hover:text-white border border-transparent'
+                    }`}
+                    key={key}
+                    onClick={() => setActiveFilter(key)}
+                  >
+                    {icon}
+                    {label}
+                    <span
+                      className={`text-xs ${activeFilter === key ? 'text-primary' : 'text-white/60'}`}
+                    >
+                      ({count})
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              {/* UTXO list */}
+              <div className="space-y-3">
+                {(activeFilter === 'all' || activeFilter === 'colorable') &&
+                  colorableUtxos.map((u: any) => (
+                    <UTXOCard key={u.utxo?.outpoint} unspent={u} />
+                  ))}
+                {(activeFilter === 'all' || activeFilter === 'colored') &&
+                  coloredUtxos.map((u: any) => (
+                    <UTXOCard key={u.utxo?.outpoint} unspent={u} />
+                  ))}
+                {(activeFilter === 'all' || activeFilter === 'normal') &&
+                  normalUtxos.map((u: any) => (
+                    <UTXOCard key={u.utxo?.outpoint} unspent={u} />
+                  ))}
+              </div>
+            </div>
+          ) : (
+            <div className="text-center py-8 text-content-secondary text-sm">
+              {t('utxoManagement.empty')}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="p-6 space-y-6">
+          {/* Description */}
+          <div className="flex items-start gap-3 rounded-lg bg-blue-500/10 border border-blue-500/20 p-4">
+            <Info className="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-blue-300">
+              {t('createUtxos.description')}
+            </p>
+          </div>
+
+          <form className="space-y-6" onSubmit={handleSubmit(onSubmitCreate)}>
+            {/* Number of UTXOs */}
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-content-secondary">
+                {t('createUtxos.fields.numberOfUtxos')}
+              </label>
+              <input
+                {...register('num', { valueAsNumber: true })}
+                className="w-full bg-surface-overlay/50 text-white px-4 py-2.5 rounded-lg border border-border-default
+                         focus:border-primary/50 focus:ring-1 focus:ring-primary/20 focus:outline-none text-sm"
+                max={10}
+                min={1}
+                placeholder={t('createUtxos.fields.numberPlaceholder')}
+                type="number"
+              />
+            </div>
+
+            {/* UTXO Size */}
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-content-secondary">
+                {t('createUtxos.fields.sizeLabel')}
+              </label>
+              <div className="flex items-center gap-4">
+                <input
+                  {...register('size', { valueAsNumber: true })}
+                  className="flex-1 bg-surface-overlay/50 text-white px-4 py-2.5 rounded-lg border border-border-default
+                           focus:border-primary/50 focus:ring-1 focus:ring-primary/20 focus:outline-none text-sm"
+                  max={
+                    btcBalanceResponse.data
+                      ? Math.floor(
+                          (btcBalanceResponse.data?.vanilla?.spendable ?? 0) /
+                            num
+                        )
+                      : 0
+                  }
+                  min={0}
+                  placeholder={t('createUtxos.fields.sizePlaceholder')}
+                  type="number"
+                />
+                <span className="text-base font-semibold text-white min-w-[100px] text-right">
+                  {size.toLocaleString()}
+                </span>
+              </div>
+              <input
+                className="w-full h-2 bg-surface-high rounded-lg appearance-none cursor-pointer mt-2"
+                max={
+                  btcBalanceResponse.data
+                    ? Math.floor(
+                        (btcBalanceResponse.data?.vanilla?.spendable ?? 0) / num
+                      )
+                    : 0
+                }
+                min={0}
+                onChange={(e) => setValue('size', Number(e.target.value))}
+                step="1000"
+                type="range"
+                value={size}
+              />
+            </div>
+
+            {/* Available balance */}
+            <p className="text-sm text-content-secondary">
+              {t('createUtxos.fields.availableBalance', {
+                defaultValue: 'Available Balance',
+              })}
+              :{' '}
+              <span className="text-white font-semibold">
+                {btcBalanceResponse.data
+                  ? (
+                      btcBalanceResponse.data?.vanilla?.spendable ?? 0
+                    ).toLocaleString()
+                  : '0'}{' '}
+                sats
+              </span>
+            </p>
+
+            {/* Fee Rate */}
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-content-secondary">
+                {t('createUtxos.fields.feeRate')}
+              </label>
+              <div className="grid grid-cols-4 gap-2">
+                {feeRateOptions.map((fee) => (
+                  <button
+                    className={`py-1.5 px-2 flex flex-col items-center justify-center gap-0.5
+                            rounded-lg transition-colors duration-200 border text-xs
+                            ${
+                              feeRate === fee.value
+                                ? 'bg-primary/10 border-primary text-primary'
+                                : 'border-border-default hover:border-primary/50 text-content-secondary'
+                            }`}
+                    key={fee.value}
+                    onClick={() => setValue('fee_rate', fee.value)}
+                    type="button"
+                  >
+                    {fee.icon}
+                    <span className="text-[10px]">{fee.label}</span>
+                    <span className="text-[9px]">{fee.rate} sat/vB</span>
+                  </button>
+                ))}
+              </div>
+              {feeRate === 'custom' && (
+                <input
+                  className="w-full bg-surface-overlay/50 text-white px-4 py-2.5 mt-2 rounded-lg border border-border-default
+                           focus:border-primary/50 focus:ring-1 focus:ring-primary/20 focus:outline-none text-sm"
+                  defaultValue={customFee}
+                  onChange={(e) => setCustomFee(parseFloat(e.target.value))}
+                  step={0.1}
+                  type="number"
+                />
+              )}
+            </div>
+
+            {/* Footer actions */}
+            <div className="flex justify-between items-center pt-2">
+              <button
+                className="px-3 py-2 text-content-secondary hover:text-white transition-colors flex items-center gap-1.5 hover:bg-surface-overlay/50 rounded-lg text-sm"
+                onClick={() => setStep('list')}
+                type="button"
+              >
+                <ArrowLeft className="w-3.5 h-3.5" />
+                <span>{t('common.back')}</span>
+              </button>
+              <button
+                className="px-4 py-2 bg-primary hover:bg-primary-emphasis disabled:opacity-50 disabled:cursor-not-allowed
+                         text-primary-foreground rounded-lg transition-colors flex items-center gap-1.5 text-sm font-semibold"
+                disabled={isCreating}
+                type="submit"
+              >
+                {isCreating ? (
+                  <Loader className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Plus className="w-4 h-4" />
+                )}
+                {t('createUtxos.actions.create')}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </Modal>
   )
 }

--- a/src/helpers/walletHistoryUtils.ts
+++ b/src/helpers/walletHistoryUtils.ts
@@ -49,6 +49,19 @@ export const formatAssetAmount = (
     })
 }
 
+// On-chain transaction types that are NOT plain BTC deposits/withdrawals:
+// `RgbSend` (an RGB-colored asset send) and `CreateUtxos` (internal UTXO
+// creation for RGB). RGB asset movements are surfaced in the Assets history
+// instead, so they are excluded from BTC deposit/withdraw history. Every other
+// type (`Incoming`, `SendBtc`, `Drain`, and the legacy `User`) is treated as a
+// BTC wallet movement; its direction is derived from the net sent/received
+// amount, which keeps this correct across node `transaction_type` renames.
+const NON_BTC_WALLET_TX_TYPES = new Set(['RgbSend', 'CreateUtxos'])
+
+export const isBtcWalletTx = (
+  transactionType: string | null | undefined
+): boolean => !NON_BTC_WALLET_TX_TYPES.has(transactionType ?? '')
+
 export const resolveAssetInfo = (
   assetId: string | null | undefined,
   listAssetsData: any

--- a/src/routes/channels/index.tsx
+++ b/src/routes/channels/index.tsx
@@ -393,7 +393,7 @@ export const Component: React.FC = () => {
                   }`}
                   onClick={() => setActiveTab('bitcoin')}
                 >
-                  <Bitcoin className="h-3.5 w-3.5 text-primary" />
+                  <Bitcoin className="h-3.5 w-3.5" />
                   {t('channels.bitcoin')}
                   <span
                     className={`text-xs ${activeTab === 'bitcoin' ? 'text-primary' : 'text-white/60'}`}

--- a/src/routes/kaleido-mind/brain-launcher.tsx
+++ b/src/routes/kaleido-mind/brain-launcher.tsx
@@ -20,6 +20,7 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { KALEIDO_MIND_MODELS_PATH } from '../../app/router/paths'
+import { Select } from '../../components/ui/Select'
 import type { UseMindResult } from '../../hooks/useMind'
 
 import { gb, labelForPhase } from './shared'
@@ -245,39 +246,15 @@ const StartBrain: React.FC<{ mind: UseMindResult }> = ({ mind }) => {
 
       <div className="mt-5 space-y-3">
         {installed.length > 1 && (
-          <div className="relative">
-            <select
-              className="appearance-none w-full pl-9 pr-8 py-2 border border-border-default rounded-lg bg-surface-overlay text-sm text-content-primary focus:outline-none focus:ring-2 focus:ring-primary"
-              onChange={(e) => setSelected(e.target.value)}
-              value={modelId}
-            >
-              {installed.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.displayName || m.id}
-                  {m.id === lastId ? ' · last used' : ''}
-                </option>
-              ))}
-            </select>
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <Cpu className="h-4 w-4 text-content-tertiary" />
-            </div>
-            <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-              <svg
-                className="h-4 w-4 text-content-tertiary"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9l-7 7-7-7"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                />
-              </svg>
-            </div>
-          </div>
+          <Select
+            icon={<Cpu className="h-4 w-4" />}
+            onChange={(val) => setSelected(val)}
+            options={installed.map((m) => ({
+              label: `${m.displayName || m.id}${m.id === lastId ? ' · last used' : ''}`,
+              value: m.id,
+            }))}
+            value={modelId}
+          />
         )}
         <button
           className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-primary px-3.5 py-2.5 text-sm font-semibold text-surface-base transition-all hover:bg-primary-emphasis active:scale-95 disabled:opacity-50"

--- a/src/routes/kaleido-mind/start-brain-modal.tsx
+++ b/src/routes/kaleido-mind/start-brain-modal.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { KALEIDO_MIND_BRAIN_PATH } from '../../app/router/paths'
 import { Modal } from '../../components/ui/Modal'
+import { Select } from '../../components/ui/Select'
 import type { UseMindResult } from '../../hooks/useMind'
 
 /** Remembers the last model you started, so "the latest" is the one you used. */
@@ -84,44 +85,20 @@ export const StartBrainModal: React.FC<{
         {installed.length > 0 ? (
           <>
             {installed.length > 1 && (
-              <label className="block">
+              <div className="block">
                 <span className="mb-1 block text-xs text-content-tertiary">
                   Model
                 </span>
-                <div className="relative">
-                  <select
-                    className="appearance-none w-full pl-9 pr-8 py-2 border border-border-default rounded-lg bg-surface-overlay text-sm text-content-primary focus:outline-none focus:ring-2 focus:ring-primary"
-                    onChange={(e) => setSelected(e.target.value)}
-                    value={modelId}
-                  >
-                    {installed.map((m) => (
-                      <option key={m.id} value={m.id}>
-                        {m.displayName || m.id}
-                        {m.id === lastId ? ' · last used' : ''}
-                      </option>
-                    ))}
-                  </select>
-                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                    <Cpu className="h-4 w-4 text-content-tertiary" />
-                  </div>
-                  <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                    <svg
-                      className="h-4 w-4 text-content-tertiary"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M19 9l-7 7-7-7"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </label>
+                <Select
+                  icon={<Cpu className="h-4 w-4" />}
+                  onChange={(val) => setSelected(val)}
+                  options={installed.map((m) => ({
+                    label: `${m.displayName || m.id}${m.id === lastId ? ' · last used' : ''}`,
+                    value: m.id,
+                  }))}
+                  value={modelId}
+                />
+              </div>
             )}
             <div className="flex gap-2">
               <button

--- a/src/routes/wallet-dashboard/index.tsx
+++ b/src/routes/wallet-dashboard/index.tsx
@@ -70,8 +70,16 @@ const BtcIcon: React.FC<{ className?: string }> = ({
 
 const ChannelAssetBadge: React.FC<{ ticker: string }> = ({ ticker }) => {
   const [imgSrc, setImgSrc] = useAssetIcon(ticker, defaultRgbIcon)
+  const isUsdt = ticker === 'USDT'
   return (
-    <span className="flex items-center gap-1 text-[10px] font-bold text-secondary bg-secondary/10 border border-secondary/20 px-1.5 py-0.5 rounded flex-shrink-0">
+    <span
+      className={`flex items-center gap-1 text-[10px] font-bold px-1.5 py-0.5 rounded flex-shrink-0 ${
+        isUsdt
+          ? 'bg-[#26A17B]/10 border border-[#26A17B]/20'
+          : 'text-secondary bg-secondary/10 border border-secondary/20'
+      }`}
+      style={isUsdt ? { color: '#26A17B' } : {}}
+    >
       <img
         alt={ticker}
         className="w-3 h-3 rounded-full object-contain"
@@ -79,6 +87,25 @@ const ChannelAssetBadge: React.FC<{ ticker: string }> = ({ ticker }) => {
         src={imgSrc}
       />
       {ticker}
+    </span>
+  )
+}
+
+const BarAssetLabel: React.FC<{ ticker: string }> = ({ ticker }) => {
+  const [imgSrc, setImgSrc] = useAssetIcon(ticker, defaultRgbIcon)
+  const isUsdt = ticker === 'USDT'
+  return (
+    <span
+      className="flex items-center justify-center gap-1 font-medium"
+      style={isUsdt ? { color: '#26A17B' } : {}}
+    >
+      <img
+        alt={ticker}
+        className="w-3 h-3 rounded-full object-contain"
+        onError={() => setImgSrc(defaultRgbIcon)}
+        src={imgSrc}
+      />
+      <span className={isUsdt ? '' : 'text-content-secondary'}>{ticker}</span>
     </span>
   )
 }
@@ -739,7 +766,7 @@ export const Component = () => {
 
                         {/* BTC liquidity bar */}
                         <div className="mb-1.5">
-                          <div className="grid grid-cols-3 items-center text-[10px] mb-0.5 max-h-0 overflow-hidden group-hover/ch:max-h-4 transition-all duration-200">
+                          <div className="grid grid-cols-3 items-center text-[10px] mb-0.5">
                             <span className="flex items-center gap-0.5 text-purple-400">
                               <ArrowUpRight className="w-2.5 h-2.5" />
                               {formatBitcoinAmount(
@@ -747,7 +774,8 @@ export const Component = () => {
                                 bitcoinUnit
                               )}
                             </span>
-                            <span className="text-center text-content-secondary font-medium">
+                            <span className="flex items-center justify-center gap-1 text-content-secondary font-medium">
+                              <BtcIcon className="w-3 h-3" />
                               BTC
                             </span>
                             <span className="flex items-center gap-0.5 text-emerald-400 justify-end">
@@ -769,7 +797,7 @@ export const Component = () => {
                             />
                             <div className="absolute top-0 bottom-0 left-1/2 -translate-x-1/2 w-px bg-surface-high/80" />
                           </div>
-                          <div className="grid grid-cols-3 text-[8px] font-semibold uppercase tracking-wider mt-0.5 max-h-0 overflow-hidden group-hover/ch:max-h-4 transition-all duration-200">
+                          <div className="grid grid-cols-3 text-[8px] font-semibold uppercase tracking-wider mt-0.5">
                             <span className="text-[#9365FF]/70">Outbound</span>
                             <span />
                             <span className="text-right text-emerald-400/70">
@@ -781,14 +809,12 @@ export const Component = () => {
                         {/* Asset liquidity bar (if RGB channel) */}
                         {asset && (
                           <div>
-                            <div className="grid grid-cols-3 items-center text-[10px] mb-0.5 max-h-0 overflow-hidden group-hover/ch:max-h-4 transition-all duration-200">
+                            <div className="grid grid-cols-3 items-center text-[10px] mb-0.5">
                               <span className="flex items-center gap-0.5 text-purple-400">
                                 <ArrowUpRight className="w-2.5 h-2.5" />
                                 {ch.asset_local_amount || 0}
                               </span>
-                              <span className="text-center text-lime-300/60 font-medium">
-                                {asset.ticker}
-                              </span>
+                              <BarAssetLabel ticker={asset.ticker} />
                               <span className="flex items-center gap-0.5 text-emerald-400 justify-end">
                                 {ch.asset_remote_amount || 0}
                                 <ArrowDownRight className="w-2.5 h-2.5" />
@@ -805,7 +831,7 @@ export const Component = () => {
                               />
                               <div className="absolute top-0 bottom-0 left-1/2 -translate-x-1/2 w-px bg-surface-high/80" />
                             </div>
-                            <div className="grid grid-cols-3 text-[8px] font-semibold uppercase tracking-wider mt-0.5 max-h-0 overflow-hidden group-hover/ch:max-h-4 transition-all duration-200">
+                            <div className="grid grid-cols-3 text-[8px] font-semibold uppercase tracking-wider mt-0.5">
                               <span className="text-[#9365FF]/70">
                                 Outbound
                               </span>

--- a/src/routes/wallet-history/deposits/index.tsx
+++ b/src/routes/wallet-history/deposits/index.tsx
@@ -25,6 +25,7 @@ import {
   formatBitcoinAmount,
   formatAssetAmount,
   resolveAssetInfo,
+  isBtcWalletTx,
 } from '../../../helpers/walletHistoryUtils'
 import { nodeApi } from '../../../slices/nodeApi/nodeApi.slice'
 
@@ -67,7 +68,7 @@ export const Component: React.FC = () => {
     refetch: refetchPayments,
   } = nodeApi.endpoints.listPayments.useQuery()
 
-  const isLoading = transactionsLoading && paymentsLoading
+  const isLoading = transactionsLoading || paymentsLoading
   const isTxError = transactionsError && !transactionsLoading
   const isPaymentsError = paymentsError && !paymentsLoading
   const isError = isTxError && isPaymentsError
@@ -147,7 +148,7 @@ export const Component: React.FC = () => {
     (transactionsData?.transactions || [])
       .filter(
         (tx: any) =>
-          tx.transaction_type === 'User' &&
+          isBtcWalletTx(tx.transaction_type) &&
           new Decimal(tx.received ?? 0).minus(tx.sent ?? 0).gt(0)
       )
       .map((tx: any) => ({
@@ -275,9 +276,6 @@ export const Component: React.FC = () => {
           {deposit.rgbAssetLabel ? (
             <>
               <span className="font-medium">{deposit.rgbAssetLabel}</span>
-              <span className="text-xs text-content-secondary">
-                {bitcoinUnit}
-              </span>
               {deposit.rgbAssetId && (
                 <div className="flex items-center">
                   {renderCopyableField(

--- a/src/routes/wallet-history/withdrawals/index.tsx
+++ b/src/routes/wallet-history/withdrawals/index.tsx
@@ -25,6 +25,7 @@ import {
   formatBitcoinAmount,
   formatAssetAmount,
   resolveAssetInfo,
+  isBtcWalletTx,
 } from '../../../helpers/walletHistoryUtils'
 import { nodeApi } from '../../../slices/nodeApi/nodeApi.slice'
 
@@ -54,7 +55,7 @@ export const Component: React.FC = () => {
     refetch: refetchPayments,
   } = nodeApi.endpoints.listPayments.useQuery()
 
-  const isLoading = transactionsLoading && paymentsLoading
+  const isLoading = transactionsLoading || paymentsLoading
   const isTxError = transactionsError && !transactionsLoading
   const isPaymentsError = paymentsError && !paymentsLoading
   const isError = isTxError && isPaymentsError
@@ -134,7 +135,7 @@ export const Component: React.FC = () => {
     (transactionsData?.transactions || [])
       .filter(
         (tx: any) =>
-          tx.transaction_type === 'User' &&
+          isBtcWalletTx(tx.transaction_type) &&
           new Decimal(tx.sent ?? 0).minus(tx.received ?? 0).gt(0)
       )
       .map((tx: any) => ({
@@ -346,9 +347,6 @@ export const Component: React.FC = () => {
                     <>
                       <span className="font-medium">
                         {withdrawal.rgbAssetLabel}
-                      </span>
-                      <span className="text-xs text-content-secondary">
-                        {bitcoinUnit}
                       </span>
                       {withdrawal.rgbAssetId && (
                         <div className="flex items-center">

--- a/src/routes/wallet-remote/index.tsx
+++ b/src/routes/wallet-remote/index.tsx
@@ -997,7 +997,7 @@ export const Component = () => {
                       <div className="pt-3 space-y-3">
                         {/* Test Connection Button */}
                         <Button
-                          className="w-full"
+                          className="w-full border-white/30 hover:border-white/50 bg-transparent hover:bg-white/5 text-white"
                           disabled={isTestingConnection || isConnecting}
                           icon={
                             isTestingConnection ? (


### PR DESCRIPTION
Conflict-free promotion of `dev` to `main` for a second **v0.5.0 retag**. Single commit whose tree is identical to `dev` and whose parent is the current `main`, so it fast-forwards cleanly (same approach as #153).

## Changes since the last dev→main promotion (#153)
- **Windows KaleidoMind fix**: win-x64 runtime now ships `bare-runtime-win32-x64` (npm `--os` normalized `win`→`win32`); runtime bumped to `mind-assets-v0.7.1`; CI fails if any platform runtime package is missing
- **Empty BTC history fix**: deposit/withdrawal history no longer filters on the nonexistent `User` transaction_type; classifies on-chain txs by excluding RGB types and derives direction from net sent/received
- **PR #154**: modal/control standardization (Peer/UTXO/Issue-Asset modals on shared `Modal`, shared `Select`, notification/mnemonic/button polish, node-switch spinner) plus channel-card polish
- **Changelog**: re-cut 0.5.0 notes for the above

Net delta matches the `main..dev` content diff (~22 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)