### PR TITLE
feat: support RLN v0.8.0 breaking API changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "decimal.js": "^10.6.0",
     "i18next": "^25.10.10",
     "i18next-browser-languagedetector": "^8.2.1",
-    "kaleido-sdk": "^0.1.13",
+    "kaleido-sdk": "^0.1.15",
     "kaleido-ui": "^0.1.92",
     "lucide-react": "^0.575.0",
     "minidenticons": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^8.2.1
         version: 8.2.1
       kaleido-sdk:
-        specifier: ^0.1.13
-        version: 0.1.13(typescript@5.9.3)
+        specifier: ^0.1.15
+        version: 0.1.15(typescript@5.9.3)
       kaleido-ui:
         specifier: ^0.1.92
         version: 0.1.92(clsx@2.1.1)(react-dom@18.3.1(react@18.3.1))(react-native-svg@15.15.5(react-native@0.86.0(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)(tailwind-merge@1.14.0)
@@ -2816,8 +2816,8 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
-  kaleido-sdk@0.1.13:
-    resolution: {integrity: sha512-TfL4cj8OMx9ZnzXIbchIhGe5iExR3ztBunmY05TaYxroEF4t8YZpyT0eaRYQXkBojVvmj69bzk9pTaPCkQAp6A==}
+  kaleido-sdk@0.1.15:
+    resolution: {integrity: sha512-Nlypo6+rXq6DvPEbNou89wGuXcObkyvxo1tPCCLxfME9ytAa1//Z/hn2RyUMbPieS3jvUeMiJcb0ZfAiftN2ew==}
     engines: {node: '>=18.0.0'}
 
   kaleido-ui@0.1.92:
@@ -7275,7 +7275,7 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
-  kaleido-sdk@0.1.13(typescript@5.9.3):
+  kaleido-sdk@0.1.15(typescript@5.9.3):
     dependencies:
       nostr-tools: 2.23.9(typescript@5.9.3)
       openapi-fetch: 0.15.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 allowBuilds:
   esbuild: true
   unrs-resolver: true
+minimumReleaseAgeExclude:
+  - kaleido-sdk@0.1.15
 overrides:
   ajv@<6.14.0: '>=6.14.0'
   bn.js@<5.2.3: '>=5.2.3'

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -957,7 +957,7 @@ async fn nwc_start_service(
     nwc: tauri::State<'_, Arc<NwcManager>>,
     state: tauri::State<'_, CurrentAccount>,
 ) -> Result<(), String> {
-    let (account_id, network, node_url) = {
+    let (account_id, network, node_url, proxy_endpoint) = {
         let current = state.0.read().unwrap();
         let account = current
             .as_ref()
@@ -966,6 +966,7 @@ async fn nwc_start_service(
             account.id,
             account.network.clone(),
             account.node_url.clone(),
+            account.proxy_endpoint.clone(),
         )
     };
 
@@ -973,6 +974,7 @@ async fn nwc_start_service(
         account_id,
         network,
         node_url,
+        proxy_endpoint,
         relays: Vec::new(),
     })
     .await

--- a/src-tauri/src/nwc.rs
+++ b/src-tauri/src/nwc.rs
@@ -83,6 +83,8 @@ pub struct StartConfig {
     pub network: String,
     /// Base URL of the embedded RLN, e.g. `http://127.0.0.1:3001`.
     pub node_url: String,
+    /// The account's RGB proxy endpoint, advertised on RGB invoices.
+    pub proxy_endpoint: String,
     /// Relays the service connects to / advertises. Empty → [`DEFAULT_RELAYS`].
     pub relays: Vec<String>,
 }
@@ -94,6 +96,7 @@ struct ServiceCtx {
     client: Client,
     http: reqwest::Client,
     node_url: String,
+    proxy_endpoint: String,
     network: String,
     account_id: i32,
     app_handle: Option<AppHandle>,
@@ -206,6 +209,7 @@ impl NwcManager {
             client: client.clone(),
             http: reqwest::Client::new(),
             node_url: cfg.node_url,
+            proxy_endpoint: cfg.proxy_endpoint,
             network: cfg.network,
             account_id: cfg.account_id,
             app_handle: self.app_handle.lock().unwrap().clone(),
@@ -642,7 +646,21 @@ async fn dispatch_rln(
             rln_post::<serde_json::Value>(ctx, "/listassets", body).await
         }
         "rln_asset_balance" => rln_post::<serde_json::Value>(ctx, "/assetbalance", obj()).await,
-        "rln_rgb_invoice" => rln_post::<serde_json::Value>(ctx, "/rgbinvoice", obj()).await,
+        "rln_rgb_invoice" => {
+            // RLN requires expiration_timestamp + a non-empty transport_endpoints.
+            let mut body = obj();
+            if body.get("expiration_timestamp").is_none() {
+                let exp = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() + 3600)
+                    .unwrap_or(0);
+                body["expiration_timestamp"] = serde_json::json!(exp);
+            }
+            if body.get("transport_endpoints").is_none() && !ctx.proxy_endpoint.is_empty() {
+                body["transport_endpoints"] = serde_json::json!([ctx.proxy_endpoint]);
+            }
+            rln_post::<serde_json::Value>(ctx, "/rgbinvoice", body).await
+        }
         // Lightning invoice. /lninvoice accepts an optional `asset_id` + `asset_amount`
         // to mint an RGB-over-Lightning invoice (the client supplies amt_msat etc).
         "rln_ln_invoice" => rln_post::<serde_json::Value>(ctx, "/lninvoice", obj()).await,

--- a/src/api/node-api-wrapper.ts
+++ b/src/api/node-api-wrapper.ts
@@ -63,8 +63,7 @@ import { transformSdkError } from './errors'
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 
 export type ApiResult<T> =
-  | { data: T; error?: never }
-  | { data?: never; error: FetchBaseQueryError }
+  { data: T; error?: never } | { data?: never; error: FetchBaseQueryError }
 
 export type CreateUtxosInput = Omit<CreateUtxosRequest, 'skip_sync'>
 export type LNInvoiceInput = Omit<LNInvoiceRequest, 'expiry_sec'>
@@ -76,7 +75,10 @@ export type RefreshInput = Partial<Pick<RefreshRequest, 'skip_sync' | 'filter'>>
 export type SendBtcInput = Omit<SendBtcRequest, 'skip_sync'>
 // SendRgbRequest no longer carries skip_sync as of kaleido-sdk 0.1.8.
 export type SendRgbInput = SendRgbRequest
-export type RgbInvoiceInput = Omit<RgbInvoiceRequest, 'min_confirmations'>
+export type RgbInvoiceInput = Omit<
+  RgbInvoiceRequest,
+  'min_confirmations' | 'expiration_timestamp'
+>
 
 export class NodeApiWrapper {
   constructor(private readonly client: RlnClient) {}
@@ -275,7 +277,11 @@ export class NodeApiWrapper {
     request: RgbInvoiceInput
   ): Promise<ApiResult<RgbInvoiceResponse>> {
     return this.execute(() =>
-      this.client.createRgbInvoice({ ...request, min_confirmations: 1 })
+      this.client.createRgbInvoice({
+        ...request,
+        expiration_timestamp: Math.floor(Date.now() / 1000) + 3600,
+        min_confirmations: 1,
+      })
     )
   }
 

--- a/src/api/request-defaults.ts
+++ b/src/api/request-defaults.ts
@@ -23,10 +23,7 @@ export const DEFAULT_SKIP_SYNC = false
  * is no longer part of this union — sendRgb is sent without skip_sync.
  */
 export type SkipSyncRequest =
-  | SendBtcRequest
-  | CreateUtxosRequest
-  | RefreshRequest
-  | FailTransfersRequest
+  SendBtcRequest | CreateUtxosRequest | RefreshRequest | FailTransfersRequest
 
 /**
  * Ensure skip_sync is present in requests that require it

--- a/src/app/hubs/websocketService.ts
+++ b/src/app/hubs/websocketService.ts
@@ -52,8 +52,7 @@ interface ConnectionStability {
  */
 // Reverse quote callback — avoids global event coupling between WS service and trade page.
 let _onQuoteResponseCallback:
-  | ((quote: any, direction: 'from' | 'to') => void)
-  | null = null
+  ((quote: any, direction: 'from' | 'to') => void) | null = null
 export const onQuoteResponse = (
   cb: ((quote: any, direction: 'from' | 'to') => void) | null
 ): void => {

--- a/src/components/Layout/Modal/Deposit/Step2.tsx
+++ b/src/components/Layout/Modal/Deposit/Step2.tsx
@@ -19,6 +19,7 @@ import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'react-toastify'
 
+import { useAppSelector } from '../../../../app/store/hooks'
 import { useSettings } from '../../../../hooks/useSettings'
 import btcLogo from '../../../../assets/bitcoin-logo.svg'
 import lightningLogo from '../../../../assets/lightning-logo.svg'
@@ -74,6 +75,9 @@ export const Step2 = ({ assetId, onBack, onClose, onNext }: Props) => {
   const { t } = useTranslation()
 
   const { bitcoinUnit } = useSettings()
+  const transportEndpoint = useAppSelector(
+    (state) => state.nodeSettings.data.proxy_endpoint
+  )
   const [addressQuery] = nodeApi.useLazyAddressQuery()
   const [lnInvoice] = nodeApi.useLnInvoiceMutation()
   const [rgbInvoice] = nodeApi.useRgbInvoiceMutation()
@@ -445,6 +449,10 @@ export const Step2 = ({ assetId, onBack, onClose, onNext }: Props) => {
 
       if (assignment) {
         requestBody.assignment = assignment
+      }
+
+      if (transportEndpoint) {
+        requestBody.transport_endpoints = [transportEndpoint]
       }
 
       const res = await rgbInvoice(requestBody)

--- a/src/components/Layout/Modal/Withdraw/index.tsx
+++ b/src/components/Layout/Modal/Withdraw/index.tsx
@@ -1209,8 +1209,7 @@ export const WithdrawModalContent: React.FC<{ onClose: () => void }> = ({
 
             // Check if recipient is witness type and provide witness_data
             let witnessData:
-              | { amount_sat: number; blinding?: number }
-              | undefined = undefined
+              { amount_sat: number; blinding?: number } | undefined = undefined
             if (decodedRgbInvoice.recipient_type === 'Witness') {
               // For witness recipients, we need to provide witness_data
               // The amount_sat is the Bitcoin amount (in sats) to send to the recipient
@@ -1230,6 +1229,7 @@ export const WithdrawModalContent: React.FC<{ onClose: () => void }> = ({
               decodedRgbInvoice.asset_id || pendingData.asset_id
             res = await sendRgb({
               donation: pendingData.donation || false,
+              expiration_timestamp: Math.floor(Date.now() / 1000) + 86400,
               fee_rate:
                 pendingData.fee_rate !== 'custom'
                   ? feeEstimations[
@@ -1256,6 +1256,7 @@ export const WithdrawModalContent: React.FC<{ onClose: () => void }> = ({
             }
             res = await sendRgb({
               donation: pendingData.donation || false,
+              expiration_timestamp: Math.floor(Date.now() / 1000) + 86400,
               fee_rate:
                 pendingData.fee_rate !== 'custom'
                   ? feeEstimations[

--- a/src/components/Layout/Modal/Withdraw/types.ts
+++ b/src/components/Layout/Modal/Withdraw/types.ts
@@ -31,12 +31,7 @@ export interface FeeEstimations {
 
 // Address type enum
 export type AddressType =
-  | 'unknown'
-  | 'bitcoin'
-  | 'lightning'
-  | 'lightning-address'
-  | 'rgb'
-  | 'invalid'
+  'unknown' | 'bitcoin' | 'lightning' | 'lightning-address' | 'rgb' | 'invalid'
 
 // Payment status type
 export type PaymentStatus = HTLCStatus | 'Expired' | null

--- a/src/components/NotificationSystem/index.tsx
+++ b/src/components/NotificationSystem/index.tsx
@@ -15,11 +15,7 @@ import { UpdateModal } from './UpdateModal'
 const DEFAULT_NOTIFICATION_AUTO_CLOSE_MS = 5000
 
 export type NotificationType =
-  | 'success'
-  | 'error'
-  | 'warning'
-  | 'info'
-  | 'loading'
+  'success' | 'error' | 'warning' | 'info' | 'loading'
 
 export interface Notification {
   id: string

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,13 +1,7 @@
 import React, { ReactNode } from 'react'
 
 export type BadgeVariant =
-  | 'default'
-  | 'primary'
-  | 'success'
-  | 'warning'
-  | 'danger'
-  | 'info'
-  | 'purple'
+  'default' | 'primary' | 'success' | 'warning' | 'danger' | 'info' | 'purple'
 export type BadgeSize = 'sm' | 'md' | 'lg'
 
 interface BadgeProps {

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -2,13 +2,7 @@ import { Loader } from 'lucide-react'
 import React, { ButtonHTMLAttributes, ReactNode } from 'react'
 
 export type ButtonVariant =
-  | 'primary'
-  | 'secondary'
-  | 'danger'
-  | 'success'
-  | 'outline'
-  | 'ghost'
-  | 'link'
+  'primary' | 'secondary' | 'danger' | 'success' | 'outline' | 'ghost' | 'link'
 export type ButtonSize = 'sm' | 'md' | 'lg'
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,11 +10,7 @@ export const COIN_ICON_URL =
   'https://raw.githubusercontent.com/kaleidoswap/coinmarketcap-icons-cryptos/refs/heads/main/icons/'
 
 export type BitcoinNetwork =
-  | 'Regtest'
-  | 'Testnet'
-  | 'Mainnet'
-  | 'Signet'
-  | 'SignetCustom'
+  'Regtest' | 'Testnet' | 'Mainnet' | 'Signet' | 'SignetCustom'
 
 const NETWORK_DISPLAY_NAMES: Record<string, string> = {
   SignetCustom: 'Mutinynet',

--- a/src/hooks/useBackup.ts
+++ b/src/hooks/useBackup.ts
@@ -78,7 +78,6 @@ export const useBackup = ({
         bitcoind_rpc_username: rpcConfig.username,
         indexer_url: nodeSettings.indexer_url,
         password,
-        proxy_endpoint: nodeSettings.proxy_endpoint,
       }).unwrap()
       return { data: {}, status: 200 }
     } catch (err) {
@@ -166,7 +165,6 @@ export const useBackup = ({
       bitcoind_rpc_username: rpcConfig.username,
       indexer_url: nodeSettings.indexer_url,
       password: data.nodePassword,
-      proxy_endpoint: nodeSettings.proxy_endpoint,
     }).unwrap()
     toast.success('Backup successful')
   }

--- a/src/routes/order-new-channel/Step4.tsx
+++ b/src/routes/order-new-channel/Step4.tsx
@@ -58,12 +58,7 @@ export const Step4: React.FC<StepProps> = ({
   const { bitcoinUnit } = useSettings()
 
   type PaymentStateType =
-    | 'waiting'
-    | 'processing'
-    | 'success'
-    | 'error'
-    | 'expired'
-    | null
+    'waiting' | 'processing' | 'success' | 'error' | 'expired' | null
   const [localPaymentState, setLocalPaymentState] =
     useState<PaymentStateType>(null)
   const [isOrderExpired, setIsOrderExpired] = useState(false)

--- a/src/routes/trade/limit-orders/components/CreateLimitOrderForm.tsx
+++ b/src/routes/trade/limit-orders/components/CreateLimitOrderForm.tsx
@@ -104,8 +104,7 @@ export function CreateLimitOrderForm({ onCreated }: Props) {
     )
     if (!pair) return { pair: null, side: null }
     const side = (getAssetId(pair.base) === fromAsset ? 'sell' : 'buy') as
-      | 'buy'
-      | 'sell'
+      'buy' | 'sell'
     return { pair, side }
   }, [activePairs, fromAsset, toAsset])
 

--- a/src/routes/wallet-history/assets/index.tsx
+++ b/src/routes/wallet-history/assets/index.tsx
@@ -175,6 +175,8 @@ export const Component = () => {
         return 'danger'
       case 'WaitingConfirmations':
       case 'WaitingCounterparty':
+      case 'WaitingSafeHeight':
+      case 'WaitingBroadcast':
         return 'warning'
       default:
         return 'default'

--- a/src/routes/wallet-history/channel-orders/index.tsx
+++ b/src/routes/wallet-history/channel-orders/index.tsx
@@ -60,8 +60,7 @@ const getOrderDeliveryMetadata = (
   orderData?: Lsps1CreateOrderResponse
 ): OrderDeliveryMetadata =>
   (orderData as
-    | (Lsps1CreateOrderResponse & OrderDeliveryMetadata)
-    | undefined) || {}
+    (Lsps1CreateOrderResponse & OrderDeliveryMetadata) | undefined) || {}
 
 const getAvailableColumns = (t: any) => [
   {

--- a/src/routes/wallet-init/index.tsx
+++ b/src/routes/wallet-init/index.tsx
@@ -110,12 +110,7 @@ interface NodeSetupFields {
 }
 
 type SetupStep =
-  | 'terms'
-  | 'setup'
-  | 'password'
-  | 'mnemonic'
-  | 'verify'
-  | 'unlock'
+  'terms' | 'setup' | 'password' | 'mnemonic' | 'verify' | 'unlock'
 
 export const Component = () => {
   const { t } = useTranslation()

--- a/src/routes/wallet-unlock/index.tsx
+++ b/src/routes/wallet-unlock/index.tsx
@@ -233,7 +233,6 @@ export const Component = () => {
             bitcoind_rpc_username: rpcConfig.username,
             indexer_url: nodeSettings.indexer_url,
             password: data.password,
-            proxy_endpoint: nodeSettings.proxy_endpoint,
           })
             .unwrap()
             .then(() => undefined),

--- a/src/slices/limitOrderSlice.ts
+++ b/src/slices/limitOrderSlice.ts
@@ -2,11 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 export type LimitOrderSide = 'buy' | 'sell'
 export type LimitOrderStatus =
-  | 'active'
-  | 'paused'
-  | 'filled'
-  | 'expired'
-  | 'cancelled'
+  'active' | 'paused' | 'filled' | 'expired' | 'cancelled'
 
 export interface LimitOrderExecution {
   id: string

--- a/src/utils/nodeUnlock.ts
+++ b/src/utils/nodeUnlock.ts
@@ -4,10 +4,7 @@ export interface NodeInfoResponseLike {
 }
 
 export type UnlockNodeOutcome =
-  | 'already-unlocked'
-  | 'cancelled'
-  | 'needs-init'
-  | 'unlocked'
+  'already-unlocked' | 'cancelled' | 'needs-init' | 'unlocked'
 
 interface VerifyUnlockedNodeOptions {
   getNodeInfo: () => Promise<NodeInfoResponseLike>


### PR DESCRIPTION
Adapts the desktop app to RLN **v0.8.0** (breaking). Consumes `kaleido-sdk@0.1.15`.

## Changes
- Bump `kaleido-sdk` → `0.1.15` (RLN 0.8.0 models); `pnpm-workspace.yaml` excludes it from the min-release-age gate.
- **RGB invoice**: wrapper injects the now-mandatory `expiration_timestamp`; deposit sends `transport_endpoints` from the node's proxy.
- **RGB send**: add mandatory `expiration_timestamp` to both `sendRgb` paths.
- **/unlock**: stop sending `proxy_endpoint` (removed in 0.8.0 — LN consignments now travel over p2p).
- Handle the new `WaitingBroadcast` transfer status (badge).
- **NWC bridge** (Tauri): thread the account proxy through and inject `expiration_timestamp` + `transport_endpoints` on `/rgbinvoice`.

## Verification
TS build + `cargo check` + full unit suite (1099 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)